### PR TITLE
Constant time step for FNPF.

### DIFF
--- a/fnpf_timestep.cpp
+++ b/fnpf_timestep.cpp
@@ -119,10 +119,13 @@ void fnpf_timestep::start(fdm_fnpf *c, lexer *p,ghostcell *pgc)
 
     
 	p->dt=pgc->timesync(p->dt);
-
+    if (p->N48 == 0) {
+        p->dt=maxtimestep;
+    }
+    else{
 	p->dt=MIN(p->dt,maxtimestep);
-	p->turbtimestep=p->dt;
-
+    }
+    p->turbtimestep=p->dt;
 }
 
 void fnpf_timestep::ini(fdm_fnpf* c, lexer* p,ghostcell* pgc)


### PR DESCRIPTION
Constant time step is aviable now for fnpf. The value of N48 is check…ed if it equals 0 dt equals maxtimestep else the same as before with adaptive time step.