### PR TITLE
Update fnpf_state_filename.cpp

### DIFF
--- a/fnpf_state_filename.cpp
+++ b/fnpf_state_filename.cpp
@@ -25,257 +25,27 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 void fnpf_state::filename(lexer *p, fdm_fnpf *c, ghostcell *pgc, int num)
 {
     
-if(p->P14==0)
-{
-	if(p->mpirank<9)
-	{
-		if(num<10)
-		sprintf(name,"REEF3D_FNPF-State-00000%d-0000%d.r3d",num,p->mpirank+1);
+  if(p->P14==0)
+  {
+    sprintf(name,"REEF3D_FNPF-State-%09d-%05d.r3d",num,p->mpirank+1);
+  }
 
-		if(num<100&&num>9)
-		sprintf(name,"REEF3D_FNPF-State-0000%d-0000%d.r3d",num,p->mpirank+1);
-
-		if(num<1000&&num>99)
-		sprintf(name,"REEF3D_FNPF-State-000%d-0000%d.r3d",num,p->mpirank+1);
-
-		if(num<10000&&num>999)
-		sprintf(name,"REEF3D_FNPF-State-00%d-0000%d.r3d",num,p->mpirank+1);
-
-		if(num<100000&&num>9999)
-		sprintf(name,"REEF3D_FNPF-State-0%d-0000%d.r3d",num,p->mpirank+1);
-
-		if(num>99999)
-		sprintf(name,"REEF3D_FNPF-State-%d-0000%d.r3d",num,p->mpirank+1);
-	}
-
-	if(p->mpirank<99&&p->mpirank>8)
-	{
-		if(num<10)
-		sprintf(name,"REEF3D_FNPF-State-00000%d-000%d.r3d",num,p->mpirank+1);
-
-		if(num<100&&num>9)
-		sprintf(name,"REEF3D_FNPF-State-0000%d-000%d.r3d",num,p->mpirank+1);
-
-		if(num<1000&&num>99)
-		sprintf(name,"REEF3D_FNPF-State-000%d-000%d.r3d",num,p->mpirank+1);
-
-		if(num<10000&&num>999)
-		sprintf(name,"REEF3D_FNPF-State-00%d-000%d.r3d",num,p->mpirank+1);
-
-		if(num<100000&&num>9999)
-		sprintf(name,"REEF3D_FNPF-State-0%d-000%d.r3d",num,p->mpirank+1);
-
-		if(num>99999)
-		sprintf(name,"REEF3D_FNPF-State-%d-000%d.r3d",num,p->mpirank+1);
-	}
-	if(p->mpirank<999&&p->mpirank>98)
-	{
-		if(num<10)
-		sprintf(name,"REEF3D_FNPF-State-00000%d-00%d.r3d",num,p->mpirank+1);
-
-		if(num<100&&num>9)
-		sprintf(name,"REEF3D_FNPF-State-0000%d-00%d.r3d",num,p->mpirank+1);
-
-		if(num<1000&&num>99)
-		sprintf(name,"REEF3D_FNPF-State-000%d-00%d.r3d",num,p->mpirank+1);
-
-		if(num<10000&&num>999)
-		sprintf(name,"REEF3D_FNPF-State-00%d-00%d.r3d",num,p->mpirank+1);
-
-		if(num<100000&&num>9999)
-		sprintf(name,"REEF3D_FNPF-State-0%d-00%d.r3d",num,p->mpirank+1);
-
-		if(num>99999)
-		sprintf(name,"REEF3D_FNPF-State-%d-00%d.r3d",num,p->mpirank+1);
-	}
-
-	if(p->mpirank<9999&&p->mpirank>998)
-	{
-		if(num<10)
-		sprintf(name,"REEF3D_FNPF-State-00000%d-0%d.r3d",num,p->mpirank+1);
-
-		if(num<100&&num>9)
-		sprintf(name,"REEF3D_FNPF-State-0000%d-0%d.r3d",num,p->mpirank+1);
-
-		if(num<1000&&num>99)
-		sprintf(name,"REEF3D_FNPF-State-000%d-0%d.r3d",num,p->mpirank+1);
-
-		if(num<10000&&num>999)
-		sprintf(name,"REEF3D_FNPF-State-00%d-0%d.r3d",num,p->mpirank+1);
-
-		if(num<100000&&num>9999)
-		sprintf(name,"REEF3D_FNPF-State-0%d-0%d.r3d",num,p->mpirank+1);
-
-		if(num>99999)
-		sprintf(name,"REEF3D_FNPF-State-%d-0%d.r3d",num,p->mpirank+1);
-	}
-
-	if(p->mpirank>9998)
-	{
-		if(num<10)
-		sprintf(name,"REEF3D_FNPF-State-00000%d-%d.r3d",num,p->mpirank+1);
-
-		if(num<100&&num>9)
-		sprintf(name,"REEF3D_FNPF-State-0000%d-%d.r3d",num,p->mpirank+1);
-
-		if(num<1000&&num>99)
-		sprintf(name,"REEF3D_FNPF-State-000%d-%d.r3d",num,p->mpirank+1);
-
-		if(num<10000&&num>999)
-		sprintf(name,"REEF3D_FNPF-State-00%d-%d.r3d",num,p->mpirank+1);
-
-		if(num<100000&&num>9999)
-		sprintf(name,"REEF3D_FNPF-State-0%d-%d.r3d",num,p->mpirank+1);
-
-		if(num>99999)
-		sprintf(name,"REEF3D_FNPF-State-%d-%d.r3d",num,p->mpirank+1);
-	}
-}
-
-if(p->P14==1)
-{
-	if(p->mpirank<9)
-	{
-		if(num<10)
-		sprintf(name,"./REEF3D_FNPF_State/REEF3D_FNPF-State-00000%d-0000%d.r3d",num,p->mpirank+1);
-
-		if(num<100&&num>9)
-		sprintf(name,"./REEF3D_FNPF_State/REEF3D_FNPF-State-0000%d-0000%d.r3d",num,p->mpirank+1);
-
-		if(num<1000&&num>99)
-		sprintf(name,"./REEF3D_FNPF_State/REEF3D_FNPF-State-000%d-0000%d.r3d",num,p->mpirank+1);
-
-		if(num<10000&&num>999)
-		sprintf(name,"./REEF3D_FNPF_State/REEF3D_FNPF-State-00%d-0000%d.r3d",num,p->mpirank+1);
-
-		if(num<100000&&num>9999)
-		sprintf(name,"./REEF3D_FNPF_State/REEF3D_FNPF-State-0%d-0000%d.r3d",num,p->mpirank+1);
-
-		if(num>99999)
-		sprintf(name,"./REEF3D_FNPF_State/REEF3D_FNPF-State-%d-0000%d.r3d",num,p->mpirank+1);
-	}
-
-	if(p->mpirank<99&&p->mpirank>8)
-	{
-		if(num<10)
-		sprintf(name,"./REEF3D_FNPF_State/REEF3D_FNPF-State-00000%d-000%d.r3d",num,p->mpirank+1);
-
-		if(num<100&&num>9)
-		sprintf(name,"./REEF3D_FNPF_State/REEF3D_FNPF-State-0000%d-000%d.r3d",num,p->mpirank+1);
-
-		if(num<1000&&num>99)
-		sprintf(name,"./REEF3D_FNPF_State/REEF3D_FNPF-State-000%d-000%d.r3d",num,p->mpirank+1);
-
-		if(num<10000&&num>999)
-		sprintf(name,"./REEF3D_FNPF_State/REEF3D_FNPF-State-00%d-000%d.r3d",num,p->mpirank+1);
-
-		if(num<100000&&num>9999)
-		sprintf(name,"./REEF3D_FNPF_State/REEF3D_FNPF-State-0%d-000%d.r3d",num,p->mpirank+1);
-
-		if(num>99999)
-		sprintf(name,"./REEF3D_FNPF_State/REEF3D_FNPF-State-%d-000%d.r3d",num,p->mpirank+1);
-	}
-	if(p->mpirank<999&&p->mpirank>98)
-	{
-		if(num<10)
-		sprintf(name,"./REEF3D_FNPF_State/REEF3D_FNPF-State-00000%d-00%d.r3d",num,p->mpirank+1);
-
-		if(num<100&&num>9)
-		sprintf(name,"./REEF3D_FNPF_State/REEF3D_FNPF-State-0000%d-00%d.r3d",num,p->mpirank+1);
-
-		if(num<1000&&num>99)
-		sprintf(name,"./REEF3D_FNPF_State/REEF3D_FNPF-State-000%d-00%d.r3d",num,p->mpirank+1);
-
-		if(num<10000&&num>999)
-		sprintf(name,"./REEF3D_FNPF_State/REEF3D_FNPF-State-00%d-00%d.r3d",num,p->mpirank+1);
-
-		if(num<100000&&num>9999)
-		sprintf(name,"./REEF3D_FNPF_State/REEF3D_FNPF-State-0%d-00%d.r3d",num,p->mpirank+1);
-
-		if(num>99999)
-		sprintf(name,"./REEF3D_FNPF_State/REEF3D_FNPF-State-%d-00%d.r3d",num,p->mpirank+1);
-	}
-
-	if(p->mpirank<9999&&p->mpirank>998)
-	{
-		if(num<10)
-		sprintf(name,"./REEF3D_FNPF_State/REEF3D_FNPF-State-00000%d-0%d.r3d",num,p->mpirank+1);
-
-		if(num<100&&num>9)
-		sprintf(name,"./REEF3D_FNPF_State/REEF3D_FNPF-State-0000%d-0%d.r3d",num,p->mpirank+1);
-
-		if(num<1000&&num>99)
-		sprintf(name,"./REEF3D_FNPF_State/REEF3D_FNPF-State-000%d-0%d.r3d",num,p->mpirank+1);
-
-		if(num<10000&&num>999)
-		sprintf(name,"./REEF3D_FNPF_State/REEF3D_FNPF-State-00%d-0%d.r3d",num,p->mpirank+1);
-
-		if(num<100000&&num>9999)
-		sprintf(name,"./REEF3D_FNPF_State/REEF3D_FNPF-State-0%d-0%d.r3d",num,p->mpirank+1);
-
-		if(num>99999)
-		sprintf(name,"./REEF3D_FNPF_State/REEF3D_FNPF-State-%d-0%d.r3d",num,p->mpirank+1);
-	}
-
-	if(p->mpirank>9998)
-	{
-		if(num<10)
-		sprintf(name,"./REEF3D_FNPF_State/REEF3D_FNPF-State-00000%d-%d.r3d",num,p->mpirank+1);
-
-		if(num<100&&num>9)
-		sprintf(name,"./REEF3D_FNPF_State/REEF3D_FNPF-State-0000%d-%d.r3d",num,p->mpirank+1);
-
-		if(num<1000&&num>99)
-		sprintf(name,"./REEF3D_FNPF_State/REEF3D_FNPF-State-000%d-%d.r3d",num,p->mpirank+1);
-
-		if(num<10000&&num>999)
-		sprintf(name,"./REEF3D_FNPF_State/REEF3D_FNPF-State-00%d-%d.r3d",num,p->mpirank+1);
-
-		if(num<100000&&num>9999)
-		sprintf(name,"./REEF3D_FNPF_State/REEF3D_FNPF-State-0%d-%d.r3d",num,p->mpirank+1);
-
-		if(num>99999)
-		sprintf(name,"./REEF3D_FNPF_State/REEF3D_FNPF-State-%d-%d.r3d",num,p->mpirank+1);
-	}
-}
+  if(p->P14==1)
+  {
+    sprintf(name,"./REEF3D_FNPF_State/REEF3D_FNPF-State-%09d-%05d.r3d",num,p->mpirank+1);
+  }
 }
 
 void fnpf_state::filename_header(lexer *p, fdm_fnpf *c, ghostcell *pgc)
 {
     if(p->P14==0)
     {
-	if(p->mpirank<9)
-	sprintf(name,"REEF3D-FNPF-State-Header-0000%d.r3d",p->mpirank+1);
-
-	if(p->mpirank<99&&p->mpirank>8)
-	sprintf(name,"REEF3D-FNPF-State-Header-000%d.r3d",p->mpirank+1);
-    
-	if(p->mpirank<999&&p->mpirank>98)
-	sprintf(name,"REEF3D-FNPF-State-Header-00%d.r3d",p->mpirank+1);
-
-	if(p->mpirank<9999&&p->mpirank>998)
-	sprintf(name,"REEF3D-FNPF-State-Header-0%d.r3d",p->mpirank+1);
-
-	if(p->mpirank>9998)
-	sprintf(name,"REEF3D-FNPF-State-Header-%d.r3d",p->mpirank+1);
+      sprintf(name,"REEF3D-FNPF-State-Header-%05d.r3d",p->mpirank+1);
     }
     
     if(p->P14==1)
     {
-	if(p->mpirank<9)
-	sprintf(name,"./REEF3D_FNPF_State/REEF3D-FNPF-State-Header-0000%d.r3d",p->mpirank+1);
-
-	if(p->mpirank<99&&p->mpirank>8)
-	sprintf(name,"./REEF3D_FNPF_State/REEF3D-FNPF-State-Header-000%d.r3d",p->mpirank+1);
-    
-	if(p->mpirank<999&&p->mpirank>98)
-	sprintf(name,"./REEF3D_FNPF_State/REEF3D-FNPF-State-Header-00%d.r3d",p->mpirank+1);
-
-	if(p->mpirank<9999&&p->mpirank>998)
-	sprintf(name,"./REEF3D_FNPF_State/REEF3D-FNPF-State-Header-0%d.r3d",p->mpirank+1);
-
-	if(p->mpirank>9998)
-	sprintf(name,"./REEF3D_FNPF_State/REEF3D-FNPF-State-Header-%d.r3d",p->mpirank+1);
+      sprintf(name,"./REEF3D_FNPF_State/REEF3D-FNPF-State-Header-%05d.r3d",p->mpirank+1);
     }
 }
 


### PR DESCRIPTION
Simplified the filename generation and increased the number of leading 0s from 6 to 9 iteration number and holds 5 leading 0s for the mpi partitions.