### PR TITLE
Updated bedshear_probe and bedshear_max for NHFLOW and CFD

### DIFF
--- a/src/bedprobe_line_x.cpp
+++ b/src/bedprobe_line_x.cpp
@@ -68,7 +68,10 @@ bedprobe_line_x::bedprobe_line_x(lexer *p, fdm* a, ghostcell *pgc)
 	
 	// Create Folder
 	if(p->mpirank==0)
-	mkdir("./REEF3D_CFD_SedimentLine",0777);
+    {
+        mkdir("./REEF3D_CFD_Sediment",0777);
+	    mkdir("./REEF3D_CFD_Sediment/Line",0777);
+    }
 }
 
 bedprobe_line_x::~bedprobe_line_x()
@@ -88,7 +91,7 @@ void bedprobe_line_x::start(lexer *p, fdm *a, ghostcell *pgc, ioflow *pflow)
     if(p->mpirank==0)
     {
 		// open file
-		sprintf(name,"./REEF3D_CFD_SedimentLine/REEF3D-CFD-bedprobe_line_x-%06i.dat",num);
+		sprintf(name,"./REEF3D_CFD_Sediment/Line/REEF3D-CFD-bedprobe_line_x-%06i.dat",num);
 
 		wsfout.open(name);
 

--- a/src/bedprobe_line_y.cpp
+++ b/src/bedprobe_line_y.cpp
@@ -68,7 +68,10 @@ bedprobe_line_y::bedprobe_line_y(lexer *p, fdm* a, ghostcell *pgc)
 	
 	// Create Folder
 	if(p->mpirank==0)
-	mkdir("./REEF3D_CFD_SedimentLine",0777);
+    {
+        mkdir("./REEF3D_CFD_Sediment",0777);
+	    mkdir("./REEF3D_CFD_Sediment/Line",0777);
+    }
 }
 
 bedprobe_line_y::~bedprobe_line_y()
@@ -88,7 +91,7 @@ void bedprobe_line_y::start(lexer *p, fdm *a, ghostcell *pgc, ioflow *pflow)
     if(p->mpirank==0)
     {
 		// open file
-		sprintf(name,"./REEF3D_CFD_SedimentLine/REEF3D-CFD-bedprobe_line_y-%06i.dat",num);
+		sprintf(name,"./REEF3D_CFD_Sediment/Line/REEF3D-CFD-bedprobe_line_y-%06i.dat",num);
 
 
 		

--- a/src/bedprobe_max.cpp
+++ b/src/bedprobe_max.cpp
@@ -31,12 +31,12 @@ bedprobe_max::bedprobe_max(lexer *p, fdm* a, ghostcell *pgc)
 {
 	// Create Folder
 	if(p->mpirank==0)
-	mkdir("./REEF3D_CFD_SedimentMax",0777);
+	mkdir("./REEF3D_CFD_Sediment",0777);
 	
     if(p->mpirank==0 && p->P122>0)
     {
     // open file
-	wsfout.open("./REEF3D_CFD_SedimentMax/REEF3D-CFD-Sediment-Max.dat");
+	wsfout.open("./REEF3D_CFD_Sediment/REEF3D-CFD-Sediment-Max.dat");
 
     wsfout<<"time  maximum erosion"<<endl<<endl;
     }

--- a/src/bedprobe_point.cpp
+++ b/src/bedprobe_point.cpp
@@ -36,12 +36,12 @@ bedprobe_point::bedprobe_point(lexer *p, fdm* a, ghostcell *pgc)
 	
 	// Create Folder
 	if(p->mpirank==0)
-	mkdir("./REEF3D_CFD_SedimentPoint",0777);
+	mkdir("./REEF3D_CFD_Sediment",0777);
 	
     if(p->mpirank==0 && p->P121>0)
     {
     // open file
-	wsfout.open("./REEF3D_CFD_SedimentPoint/REEF3D-CFD-Sediment-Point.dat");
+	wsfout.open("./REEF3D_CFD_Sediment/REEF3D-CFD-Sediment-Point.dat");
 
     wsfout<<"number of gauges:  "<<p->P121<<endl<<endl;
     wsfout<<"x_coord     y_coord"<<endl;

--- a/src/bedshear_max.cpp
+++ b/src/bedshear_max.cpp
@@ -22,29 +22,40 @@ Author: Hans Bihs
 
 #include"bedshear_max.h"
 #include"lexer.h"
-#include"fdm.h"
 #include"ghostcell.h"
 #include"sediment.h"
 #include<sys/stat.h>
 #include<sys/types.h>
+#include<stdio.h>
 
-bedshear_max::bedshear_max(lexer *p, fdm* a, ghostcell *pgc)
+bedshear_max::bedshear_max(lexer *p, ghostcell *pgc)
 {
 	
 	// Create Folder
 	if(p->mpirank==0)
-	mkdir("./REEF3D_CFD_SedimentMax",0777);
+    {
+        char folder[40];
+        if(p->A10==5)
+            snprintf(folder,sizeof(folder),"./REEF3D_NHFLOW_Sediment");
+        else
+            snprintf(folder,sizeof(folder),"./REEF3D_CFD_Sediment");
+	    mkdir(folder,0777);
+    }
 	
     if(p->mpirank==0 && p->P126>0)
     {
-    // open file
-	bsgout.open("./REEF3D_CFD_SedimentPoint/REEF3D-CFD-Sediment-Bedshear-Max.dat");
+        // open file
+        char file[100];
+        if(p->A10==5)
+            snprintf(file,sizeof(file),"./REEF3D_NHFLOW_Sediment/REEF3D-NHFLOW-Sediment-Bedshear-Max.dat");
+        else
+            snprintf(file,sizeof(file),"./REEF3D_CFD_Sediment/REEF3D-CFD-Sediment-Bedshear-Max.dat");
+	    bsgout.open(file);
 
+        bsgout<<"time";
+        bsgout<<"\t  bedshear max";
 
-    bsgout<<"time";
-    bsgout<<"\t  bedshear max";
-
-    bsgout<<endl<<endl;
+        bsgout<<endl<<endl;
     }
 	
 
@@ -55,7 +66,7 @@ bedshear_max::~bedshear_max()
     bsgout.close();
 }
 
-void bedshear_max::bedshear_maxval(lexer *p, fdm *a, ghostcell *pgc, sediment *psed)
+void bedshear_max::bedshear_maxval(lexer *p, ghostcell *pgc, sediment *psed)
 {
     double maxval;
 
@@ -64,7 +75,7 @@ void bedshear_max::bedshear_maxval(lexer *p, fdm *a, ghostcell *pgc, sediment *p
 	
     ILOOP
     JLOOP
-    maxval = MAX(maxval, psed->bedshear_point(p,a,pgc));
+    maxval = MAX(maxval, psed->bedshear_point(p,pgc));
 
 	
     maxval=pgc->globalmax(maxval);

--- a/src/bedshear_max.h
+++ b/src/bedshear_max.h
@@ -20,29 +20,27 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 Author: Hans Bihs
 --------------------------------------------------------------------*/
 
+#ifndef BEDSHEAR_MAX_H_
+#define BEDSHEAR_MAX_H_
+
 #include"boundarycheck.h"
 #include"bedshear.h"
 #include<iostream>
 #include<fstream>
 
 class lexer;
-class fdm;
 class ghostcell;
-class field;
 class sediment;
 
 using namespace std;
 
-#ifndef BEDSHEAR_MAX_H_
-#define BEDSHEAR_MAX_H_
-
 class bedshear_max : public boundarycheck
 {
 public:
-    bedshear_max(lexer*,fdm*,ghostcell*);
+    bedshear_max(lexer*,ghostcell*);
 	virtual ~bedshear_max();
 
-	void bedshear_maxval(lexer*, fdm*, ghostcell*, sediment*);
+	void bedshear_maxval(lexer*, ghostcell*, sediment*);
 
 
 private:

--- a/src/bedshear_probe.h
+++ b/src/bedshear_probe.h
@@ -20,34 +20,31 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 Author: Hans Bihs
 --------------------------------------------------------------------*/
 
+#ifndef BEDSHEAR_PROBE_H_
+#define BEDSHEAR_PROBE_H_
+
 #include"boundarycheck.h"
 
 #include<iostream>
 #include<fstream>
 
 class lexer;
-class fdm;
 class ghostcell;
-class field;
 class sediment;
 
 using namespace std;
 
-#ifndef BEDSHEAR_PROBE_H_
-#define BEDSHEAR_PROBE_H_
-
 class bedshear_probe : public boundarycheck
 {
 public:
-    bedshear_probe(lexer*,fdm*,ghostcell*);
+    bedshear_probe(lexer*, ghostcell*);
 	virtual ~bedshear_probe();
 
-	void bedshear_gauge(lexer*, fdm*, ghostcell*, sediment*);
+	void bedshear_gauge(lexer*, ghostcell*, sediment*);
 
 
 private:
-    void ini_location(lexer*, fdm*, ghostcell*);
-    void write(lexer*, fdm*, ghostcell*);
+    void ini_location(lexer*, ghostcell*);
     int conv(double);
 
     int *iloc,*jloc,*flag;

--- a/src/nhflow_vtu3D.cpp
+++ b/src/nhflow_vtu3D.cpp
@@ -41,6 +41,8 @@ Author: Hans Bihs
 #include"nhflow_turbulence.h"
 #include"nhflow_force.h"
 #include"nhflow_force_ale.h"
+#include"bedshear_probe.h"
+#include"bedshear_max.h"
 #include<sys/stat.h>
 #include<sys/types.h>
 
@@ -125,6 +127,12 @@ nhflow_vtu3D::nhflow_vtu3D(lexer* p, fdm_nhf *d, ghostcell *pgc)
 
     pbed = new nhflow_vtp_bed(p,d,pgc);
 
+    if(p->P125>0)
+    pbedshear = new bedshear_probe(p,pgc);
+
+    if(p->P126==1)
+    pbedshearmax = new bedshear_max(p,pgc);
+    
 }
 
 nhflow_vtu3D::~nhflow_vtu3D()
@@ -273,6 +281,13 @@ void nhflow_vtu3D::start(lexer* p, fdm_nhf* d, ghostcell* pgc, ioflow *pflow, nh
     if(p->P59==1)
     pbreaklog->write(p,d,pgc);
     */
+
+    // sediment probes
+    if(p->P125>0)
+	pbedshear->bedshear_gauge(p,pgc,psed);
+
+    if(p->P126==1)
+    pbedshearmax->bedshear_maxval(p,pgc,psed);
 }
 
 void nhflow_vtu3D::print_stop(lexer* p, fdm_nhf* d, ghostcell* pgc, ioflow *pflow, nhflow_turbulence *pnhfturb, sediment *psed)

--- a/src/nhflow_vtu3D.h
+++ b/src/nhflow_vtu3D.h
@@ -45,6 +45,8 @@ class nhflow_print_Hs;
 class nhflow_turbulence;
 class nhflow_force;
 class nhflow_force_ale;
+class bedshear_probe;
+class bedshear_max;
 
 using namespace std;
 
@@ -92,6 +94,8 @@ private:
     nhflow_print_Hs *phs;
     nhflow_force **pforce;
     nhflow_force_ale **pforce_ale;
+    bedshear_probe *pbedshear;
+    bedshear_max* pbedshearmax;
     
 };
 

--- a/src/sediment.h
+++ b/src/sediment.h
@@ -65,7 +65,7 @@ public:
     
     //
     virtual void relax(lexer*,ghostcell*){};
-	virtual double bedshear_point(lexer*,fdm*,ghostcell*){};
+	virtual double bedshear_point(lexer*,ghostcell*){};
     
     virtual double qbeval(int,int){};
     virtual void qbeget(int,int,double){};

--- a/src/sediment_f.h
+++ b/src/sediment_f.h
@@ -26,7 +26,8 @@ Author: Hans Bihs
 #include"field4a.h"
 #include"increment.h"
 
-class bedload;class bedconc;
+class bedload;
+class bedconc;
 class sandslide;
 class topo_relax;
 class bedshear;
@@ -34,7 +35,11 @@ class vrans;
 class turbulence;
 class sediment_fdm;
 class bedslope;
-class bedshear_reduction;class suspended;class diffusion;class convection;class patchBC_interface;
+class bedshear_reduction;
+class suspended;
+class diffusion;
+class convection;
+class patchBC_interface;
 class bedload_direction;
 using namespace std;
 
@@ -49,8 +54,16 @@ public:
     
     // CFD interface
     virtual void start_cfd(lexer*, fdm*, ghostcell*, ioflow*, reinitopo*, solver*);
-    virtual void ini_cfd(lexer*,fdm*,ghostcell*);    virtual void start_susp(lexer*, fdm*, ghostcell*, ioflow*, solver*);    virtual void update_cfd(lexer*,fdm*,ghostcell*,ioflow*,reinitopo*);    void sediment_logic(lexer*,fdm*,ghostcell*,turbulence*);
-    void sediment_algorithm_cfd(lexer*, fdm*, ghostcell*, ioflow*, reinitopo*, solver*);    void prep_cfd(lexer*,fdm*,ghostcell*);    void fill_PQ_cfd(lexer*,fdm*,ghostcell*);    void active_cfd(lexer*,fdm*,ghostcell*);    void active_ini_cfd(lexer*,fdm*,ghostcell*);    void bedchange_update(lexer*, ghostcell*);
+    virtual void ini_cfd(lexer*,fdm*,ghostcell*);
+    virtual void start_susp(lexer*, fdm*, ghostcell*, ioflow*, solver*);
+    virtual void update_cfd(lexer*,fdm*,ghostcell*,ioflow*,reinitopo*);
+    void sediment_logic(lexer*,fdm*,ghostcell*,turbulence*);
+    void sediment_algorithm_cfd(lexer*, fdm*, ghostcell*, ioflow*, reinitopo*, solver*);
+    void prep_cfd(lexer*,fdm*,ghostcell*);
+    void fill_PQ_cfd(lexer*,fdm*,ghostcell*);
+    void active_cfd(lexer*,fdm*,ghostcell*);
+    void active_ini_cfd(lexer*,fdm*,ghostcell*);
+    void bedchange_update(lexer*, ghostcell*);
     
     // NHFLOW interface
     virtual void start_nhflow(lexer*, fdm_nhf*, ghostcell*, ioflow*);
@@ -67,37 +80,85 @@ public:
     virtual void ini_sflow(lexer*, fdm2D*, ghostcell*);
     virtual void update_sflow(lexer*,fdm2D*,ghostcell*,ioflow*);
     void sediment_algorithm_sflow(lexer*, fdm2D*, ghostcell*, ioflow*, slice&, slice&);
-    void prep_sflow(lexer*, fdm2D*, ghostcell*,slice&,slice&);    void fill_PQ_sflow(lexer*,fdm2D*,ghostcell*,slice&,slice&);    void active_sflow(lexer*, fdm2D*, ghostcell*);    void active_ini_sflow(lexer*, fdm2D*, ghostcell*);
+    void prep_sflow(lexer*, fdm2D*, ghostcell*,slice&,slice&);
+    void fill_PQ_sflow(lexer*,fdm2D*,ghostcell*,slice&,slice&);
+    void active_sflow(lexer*, fdm2D*, ghostcell*);
+    void active_ini_sflow(lexer*, fdm2D*, ghostcell*);
     
     
-    // ---    virtual void ini_parameters(lexer*, ghostcell*);    virtual void ini_guard(lexer*, ghostcell*);
+    // ---
+
+    virtual void ini_parameters(lexer*, ghostcell*);
+    virtual void ini_guard(lexer*, ghostcell*);
 	
     virtual void relax(lexer*,ghostcell*);
-	virtual double bedshear_point(lexer*,fdm*,ghostcell*);
+	virtual double bedshear_point(lexer*,ghostcell*);
     
     virtual double qbeval(int,int);
-    virtual void qbeget(int,int,double);    virtual double bedzhval(int,int);    virtual void ctimesave(lexer*, fdm*);
+    virtual void qbeget(int,int,double);
+
+    virtual double bedzhval(int,int);
+
+    virtual void ctimesave(lexer*, fdm*);
     
     void fill_bedk(lexer*,fdm*,ghostcell*);
-	void bedlevel(lexer*,fdm*,ghostcell*);    void waterlevel(lexer*,fdm*,ghostcell*);
+	void bedlevel(lexer*,fdm*,ghostcell*);
+    void waterlevel(lexer*,fdm*,ghostcell*);
 	void topo_zh_update(lexer*,fdm*,ghostcell*,sediment_fdm*);
     void volume_calc(lexer*,fdm*,ghostcell*);
 	void filter(lexer*,ghostcell*,slice&,int,int);
     
     // print
-    virtual void print_2D_bedload(lexer*, ghostcell*,ofstream&);    virtual void print_3D_bedload(lexer*, ghostcell*,ofstream&);	virtual void name_pvtu_bedload(lexer*, ghostcell*,ofstream&);    virtual void name_vtu_bedload(lexer*, ghostcell*,ofstream&, int*, int &);    virtual void offset_vtp_bedload(lexer*, ghostcell*,ofstream&, int*, int &);    virtual void offset_vtu_bedload(lexer*, ghostcell*,ofstream&, int*, int &);    	virtual void print_2D_bedshear(lexer*, ghostcell*,ofstream&);    virtual void print_3D_bedshear(lexer*, ghostcell*,ofstream&);	virtual void name_pvtu_bedshear(lexer*, ghostcell*,ofstream&);    virtual void name_vtu_bedshear(lexer*, ghostcell*,ofstream&, int*, int &);    virtual void offset_vtp_bedshear(lexer*, ghostcell*,ofstream&, int*, int &);    virtual void offset_vtu_bedshear(lexer*, ghostcell*,ofstream&, int*, int &);        virtual void print_2D_parameter1(lexer*, ghostcell*,ofstream&);    virtual void print_3D_parameter1(lexer*, ghostcell*,ofstream&);	virtual void name_pvtu_parameter1(lexer*, ghostcell*,ofstream&);    virtual void name_vtu_parameter1(lexer*, ghostcell*,ofstream&, int*, int &);    virtual void offset_vtp_parameter1(lexer*, ghostcell*,ofstream&, int*, int &);    virtual void offset_vtu_parameter1(lexer*, ghostcell*,ofstream&, int*, int &);        virtual void print_2D_parameter2(lexer*, ghostcell*,ofstream&);    virtual void print_3D_parameter2(lexer*, ghostcell*,ofstream&);	virtual void name_pvtu_parameter2(lexer*, ghostcell*,ofstream&);    virtual void name_vtu_parameter2(lexer*, ghostcell*,ofstream&, int*, int &);    virtual void offset_vtp_parameter2(lexer*, ghostcell*,ofstream&, int*, int &);    virtual void offset_vtu_parameter2(lexer*, ghostcell*,ofstream&, int*, int &);
+    virtual void print_2D_bedload(lexer*, ghostcell*,ofstream&);
+    virtual void print_3D_bedload(lexer*, ghostcell*,ofstream&);
+	virtual void name_pvtu_bedload(lexer*, ghostcell*,ofstream&);
+    virtual void name_vtu_bedload(lexer*, ghostcell*,ofstream&, int*, int &);
+    virtual void offset_vtp_bedload(lexer*, ghostcell*,ofstream&, int*, int &);
+    virtual void offset_vtu_bedload(lexer*, ghostcell*,ofstream&, int*, int &);
+    
+	virtual void print_2D_bedshear(lexer*, ghostcell*,ofstream&);
+    virtual void print_3D_bedshear(lexer*, ghostcell*,ofstream&);
+	virtual void name_pvtu_bedshear(lexer*, ghostcell*,ofstream&);
+    virtual void name_vtu_bedshear(lexer*, ghostcell*,ofstream&, int*, int &);
+    virtual void offset_vtp_bedshear(lexer*, ghostcell*,ofstream&, int*, int &);
+    virtual void offset_vtu_bedshear(lexer*, ghostcell*,ofstream&, int*, int &);
+    
+    virtual void print_2D_parameter1(lexer*, ghostcell*,ofstream&);
+    virtual void print_3D_parameter1(lexer*, ghostcell*,ofstream&);
+	virtual void name_pvtu_parameter1(lexer*, ghostcell*,ofstream&);
+    virtual void name_vtu_parameter1(lexer*, ghostcell*,ofstream&, int*, int &);
+    virtual void offset_vtp_parameter1(lexer*, ghostcell*,ofstream&, int*, int &);
+    virtual void offset_vtu_parameter1(lexer*, ghostcell*,ofstream&, int*, int &);
+    
+    virtual void print_2D_parameter2(lexer*, ghostcell*,ofstream&);
+    virtual void print_3D_parameter2(lexer*, ghostcell*,ofstream&);
+	virtual void name_pvtu_parameter2(lexer*, ghostcell*,ofstream&);
+    virtual void name_vtu_parameter2(lexer*, ghostcell*,ofstream&, int*, int &);
+    virtual void offset_vtp_parameter2(lexer*, ghostcell*,ofstream&, int*, int &);
+    virtual void offset_vtu_parameter2(lexer*, ghostcell*,ofstream&, int*, int &);
     
 
-private:        void log_ini(lexer*);    void sedimentlog(lexer*);
+private:
+    
+    void log_ini(lexer*);
+    void sedimentlog(lexer*);
     sediment_fdm *s;
-    bedload *pbed;      bedconc *pcbed;
+    bedload *pbed;  
+    bedconc *pcbed;
     sandslide *pslide;
     topo_relax *prelax;
     vrans *pvrans;
     bedslope *pslope;
-    bedshear_reduction *preduce;    topo *ptopo;    suspended *psusp;    diffusion *psuspdiff;    convection *psuspdisc;
-	bedshear *pbedshear;    patchBC_interface *pBC;
-    bedload_direction *pbeddir;    ofstream sedlogout;
+    bedshear_reduction *preduce;
+    topo *ptopo;
+    suspended *psusp;
+    diffusion *psuspdiff;
+    convection *psuspdisc;
+	bedshear *pbedshear;
+    patchBC_interface *pBC;
+    bedload_direction *pbeddir;
+
+    ofstream sedlogout;
     
     double starttime;
     

--- a/src/sediment_io.cpp
+++ b/src/sediment_io.cpp
@@ -19,7 +19,8 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 --------------------------------------------------------------------
 Author: Hans Bihs
 --------------------------------------------------------------------*/
-#include"sediment_f.h"
+
+#include"sediment_f.h"
 #include"lexer.h"
 #include"fdm.h"
 #include"fdm_nhf.h"
@@ -28,11 +29,9 @@ Author: Hans Bihs
 #include"bedshear.h"
 #include"suspended.h"
 
-double sediment_f::bedshear_point(lexer *p, fdm *a,ghostcell *pgc)
+double sediment_f::bedshear_point(lexer *p, ghostcell *pgc)
 {
-	double tau_eff = s->tau_eff(i,j);
-    
-	return tau_eff;
+	return s->tau_eff(i,j);
 }
 
 void sediment_f::fill_bedk(lexer *p, fdm *a,ghostcell *pgc)

--- a/src/sediment_part.h
+++ b/src/sediment_part.h
@@ -91,7 +91,7 @@ public:
 
 
     virtual void relax(lexer*,ghostcell*){};
-	virtual double bedshear_point(lexer*,fdm*,ghostcell*){};
+	virtual double bedshear_point(lexer*,ghostcell*){};
     
     virtual double qbeval(int,int){};
     virtual void qbeget(int,int,double){};

--- a/src/sediment_void.cpp
+++ b/src/sediment_void.cpp
@@ -187,7 +187,7 @@ void sediment_void::offset_vtu_parameter2(lexer *p, ghostcell *pgc, ofstream &re
 {
 }
 
-double sediment_void::bedshear_point(lexer *p, fdm *a,ghostcell *pgc)
+double sediment_void::bedshear_point(lexer *p, ghostcell *pgc)
 {
 	return 0.0;
 }

--- a/src/sediment_void.h
+++ b/src/sediment_void.h
@@ -49,7 +49,7 @@ public:
     // ---
 	
     virtual void relax(lexer*,ghostcell*);
-	virtual double bedshear_point(lexer*,fdm*,ghostcell*);
+	virtual double bedshear_point(lexer*,ghostcell*);
     
     virtual double qbeval(int,int);
     virtual void qbeget(int,int,double);

--- a/src/vtr3D.cpp
+++ b/src/vtr3D.cpp
@@ -162,10 +162,10 @@ vtr3D::vtr3D(lexer* p, fdm *a, ghostcell *pgc) : eta(p)
 	pbedliney=new bedprobe_line_y(p,a,pgc);
 
 	if(p->P125>0)
-	pbedshear = new bedshear_probe(p,a,pgc);
+	pbedshear = new bedshear_probe(p,pgc);
 
 	if(p->P126>0)
-	pbedshearmax = new bedshear_max(p,a,pgc);
+	pbedshearmax = new bedshear_max(p,pgc);
 
     for(n=0;n<p->P81;++n)
 	pforce[n]=new force(p,a,pgc,n);
@@ -307,10 +307,10 @@ void vtr3D::start(fdm* a,lexer* p,ghostcell* pgc, turbulence *pturb, heat *pheat
 	pbedliney->start(p,a,pgc,pflow);
 
 	if(p->P125>0)
-	pbedshear->bedshear_gauge(p,a,pgc,psed);
+	pbedshear->bedshear_gauge(p,pgc,psed);
 
 	if(p->P126>0)
-	pbedshearmax->bedshear_maxval(p,a,pgc,psed);
+	pbedshearmax->bedshear_maxval(p,pgc,psed);
 	}
 
 	// Multiphase

--- a/src/vts3D.cpp
+++ b/src/vts3D.cpp
@@ -162,10 +162,10 @@ vts3D::vts3D(lexer* p, fdm *a, ghostcell *pgc) : eta(p)
 	pbedliney=new bedprobe_line_y(p,a,pgc);
 
 	if(p->P125>0)
-	pbedshear = new bedshear_probe(p,a,pgc);
+	pbedshear = new bedshear_probe(p,pgc);
 
 	if(p->P126>0)
-	pbedshearmax = new bedshear_max(p,a,pgc);
+	pbedshearmax = new bedshear_max(p,pgc);
 
     for(n=0;n<p->P81;++n)
 	pforce[n]=new force(p,a,pgc,n);
@@ -309,10 +309,10 @@ void vts3D::start(fdm* a,lexer* p,ghostcell* pgc, turbulence *pturb, heat *pheat
 	pbedliney->start(p,a,pgc,pflow);
 
 	if(p->P125>0)
-	pbedshear->bedshear_gauge(p,a,pgc,psed);
+	pbedshear->bedshear_gauge(p,pgc,psed);
 
 	if(p->P126>0)
-	pbedshearmax->bedshear_maxval(p,a,pgc,psed);
+	pbedshearmax->bedshear_maxval(p,pgc,psed);
 	}
 
 	// Multiphase

--- a/src/vtu3D.cpp
+++ b/src/vtu3D.cpp
@@ -162,10 +162,10 @@ vtu3D::vtu3D(lexer* p, fdm *a, ghostcell *pgc) : eta(p)
 	pbedliney=new bedprobe_line_y(p,a,pgc);
 
 	if(p->P125>0)
-	pbedshear = new bedshear_probe(p,a,pgc);
+	pbedshear = new bedshear_probe(p,pgc);
 
 	if(p->P126>0)
-	pbedshearmax = new bedshear_max(p,a,pgc);
+	pbedshearmax = new bedshear_max(p,pgc);
 
     for(n=0;n<p->P81;++n)
 	pforce[n]=new force(p,a,pgc,n);
@@ -309,10 +309,10 @@ void vtu3D::start(fdm* a,lexer* p,ghostcell* pgc, turbulence *pturb, heat *pheat
 	pbedliney->start(p,a,pgc,pflow);
 
 	if(p->P125>0)
-	pbedshear->bedshear_gauge(p,a,pgc,psed);
+	pbedshear->bedshear_gauge(p,pgc,psed);
 
 	if(p->P126>0)
-	pbedshearmax->bedshear_maxval(p,a,pgc,psed);
+	pbedshearmax->bedshear_maxval(p,pgc,psed);
 	}
 
 	// Multiphase


### PR DESCRIPTION
Updated bedshear probes and bedshear max for NHFLOW and CFD.
Reordered the sediment data folder structure (bedprobe lines, bedprobe max, bedprobe point, bedshear max, bedshear probe):
- REEF3D_XXXX_Sediment/
- the lines can be found in a subfolder: REEF3D_XXXX_Sediment/Line/