### PR TITLE
Added flush to wsf output

### DIFF
--- a/src/fnpf_print_wsf.cpp
+++ b/src/fnpf_print_wsf.cpp
@@ -27,7 +27,7 @@ Author: Hans Bihs
 #include<sys/stat.h>
 #include<sys/types.h>
 
-fnpf_print_wsf::fnpf_print_wsf(lexer *p, fdm_fnpf *c)
+fnpf_print_wsf::fnpf_print_wsf(lexer *p, fdm_fnpf *c) : fileFlushMaxCount(100)
 {
 
 	gauge_num = p->P51;
@@ -125,7 +125,12 @@ void fnpf_print_wsf::height_gauge(lexer *p, fdm_fnpf *c, ghostcell *pgc, slice &
     {
     wsfout<<setprecision(9)<<p->simtime<<"\t";
     for(n=0;n<gauge_num;++n)
-    wsfout<<setprecision(9)<<wsf[n]<<"  \t  ";
+    {
+        wsfout<<setprecision(9)<<wsf[n]<<"\t";
+        // flush print to disc limited to prevent data loss for many gauges
+        if(n%fileFlushMaxCount==0&&n!=0)
+            wsfout<<std::flush;
+    }
     wsfout<<endl;
     }
     

--- a/src/fnpf_print_wsf.h
+++ b/src/fnpf_print_wsf.h
@@ -56,6 +56,7 @@ private:
     double *wsf,*deta,*Uhorz;
     int n;
     ofstream wsfout,detaout,Uhorzout;
+    const int fileFlushMaxCount;
     
 
 };

--- a/src/nhflow_print_wsf.h
+++ b/src/nhflow_print_wsf.h
@@ -57,7 +57,7 @@ private:
     double *wsf,*deta,*Uhorz;
     int n;
     ofstream wsfout,detaout,Uhorzout;
-    
+    const int fileFlushMaxCount;
 
 };
 

--- a/src/print_wsf.cpp
+++ b/src/print_wsf.cpp
@@ -27,7 +27,7 @@ Author: Hans Bihs
 #include<sys/stat.h>
 #include<sys/types.h>
 
-print_wsf::print_wsf(lexer *p, fdm* a, ghostcell *pgc, int num)
+print_wsf::print_wsf(lexer *p, fdm* a, ghostcell *pgc, int num) : fileFlushMaxCount(100)
 {
 	gauge_num = p->P51;
 	x = p->P51_x;
@@ -177,7 +177,12 @@ void print_wsf::height_gauge(lexer *p, fdm *a, ghostcell *pgc, field &f)
     {
     wsfout<<setprecision(9)<<p->simtime<<"\t";
     for(n=0;n<gauge_num;++n)
-    wsfout<<setprecision(9)<<wsf[n]<<"  \t  ";
+    {
+        wsfout<<setprecision(9)<<wsf[n]<<"\t";
+        // flush print to disc limited to prevent data loss for many gauges
+        if(n%fileFlushMaxCount==0&&n!=0)
+            wsfout<<std::flush;
+    }
     wsfout<<endl;
     }
 }

--- a/src/print_wsf.h
+++ b/src/print_wsf.h
@@ -54,6 +54,7 @@ private:
     double *wsf;
     int n;
     ofstream wsfout;
+    const int fileFlushMaxCount;
 
 };
 

--- a/src/sflow_print_wsf.cpp
+++ b/src/sflow_print_wsf.cpp
@@ -27,7 +27,7 @@ Author: Hans Bihs
 #include<sys/stat.h>
 #include<sys/types.h>
 
-sflow_print_wsf::sflow_print_wsf(lexer *p, fdm2D* b)
+sflow_print_wsf::sflow_print_wsf(lexer *p, fdm2D* b) : fileFlushMaxCount(100)
 {
 
 	gauge_num = p->P51;
@@ -102,7 +102,12 @@ void sflow_print_wsf::height_gauge(lexer *p, fdm2D *b, ghostcell *pgc, slice &f)
     {
     wsfout<<setprecision(9)<<p->simtime<<"\t";
     for(n=0;n<gauge_num;++n)
-    wsfout<<setprecision(9)<<wsf[n]<<"  \t  ";
+    {
+        wsfout<<setprecision(9)<<wsf[n]<<"\t";
+        // flush print to disc limited to prevent data loss for many gauges
+        if(n%fileFlushMaxCount==0&&n!=0)
+            wsfout<<std::flush;
+    }
     wsfout<<endl;
     }
 }

--- a/src/sflow_print_wsf.h
+++ b/src/sflow_print_wsf.h
@@ -54,6 +54,7 @@ private:
     double *wsf;
     int n;
     ofstream wsfout;
+    const int fileFlushMaxCount;
 
 };
 


### PR DESCRIPTION
Due to ofstream size limitations intermittent flush is needed to prevent data loss (for gauge numbers >200).

The REEF3D-...-WSF-HG.dat lines for surface elevation data were cut off at the end for a large number of gauges, although all gauges were used. Printing from memory into the file at increment limits of 100 gauge entries fixed the problem.