### PR TITLE
Rheology related updates

### DIFF
--- a/src/fluid_update.h
+++ b/src/fluid_update.h
@@ -23,21 +23,14 @@ Author: Hans Bihs
 #ifndef FLUID_UPDATE_H_
 #define FLUID_UPDATE_H_
 
-class fdm;
 class lexer;
+class fdm;
 class ghostcell;
-class field;
-
-using namespace std;
 
 class fluid_update
 {
 public:
-
-	virtual void start(lexer*, fdm*, ghostcell*)=0;
-
-
+    virtual void start(lexer*, fdm*, ghostcell*)=0;
 };
 
 #endif
-

--- a/src/fluid_update_rheology.h
+++ b/src/fluid_update_rheology.h
@@ -40,7 +40,7 @@ public:
     void start(lexer*, fdm*, ghostcell*) override;
 
 private:
-    rheology *prheo;
+    rheology* prheo;
     int iter;
     int n;
     const double ro1,ro2;
@@ -49,7 +49,6 @@ private:
     double epsi;
 
     bool iocheck;
-
 };
 
 #endif

--- a/src/ini.cpp
+++ b/src/ini.cpp
@@ -390,13 +390,8 @@ void lexer::ini_default()
 	F80=0;             // int time scheme VOF
 	F84=1.0;             // double cgamma for vof compression
     F85=0;             // int convection scheme VOF
-    F112=0;            // int tilted wedge
-    F112_xs=-1.0e20;            // double i-dir zero level set start
-    F112_xe=-1.0e20;            // double j-dir zero level set start
-    F112_ys=-1.0e20;            // double k-dir zero level set start
-    F112_ye=1.0e20;        // double i-dir zero level set end
-    F112_zs=1.0e20;        // double j-dir zero level set end
-    F112_ze=1.0e20;        // double k-dir zero level set end
+    F112=0;            // int wedge in x-direction
+    F113=0;            // int wedge in y-direction
     F150=0;         // int benchmark
     F151=0;         // int benchmark inverse sign of level set
     F300=0;             // int multiphase flow level set

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -21,11 +21,11 @@ Author: Hans Bihs
 --------------------------------------------------------------------*/
 
 #include"initialize.h"
-#include"fdm.h"
 #include"lexer.h"
+#include"fdm.h"
 #include"ghostcell.h"
 
-initialize::initialize(lexer* p):smallnum(1.0e-20)
+initialize::initialize(lexer* p)
 {
 }
 
@@ -33,39 +33,39 @@ initialize::~initialize()
 {
 }
 
-void initialize::start(fdm* a, lexer* p, ghostcell* pgc)
-{
-	deltax=p->DXM;
-	
-	inifdm(a,p,pgc);
-	nodecalc(a,p);
-	maxcoor(a,p,pgc);
-	paraini(p,a,pgc);
-    
+void initialize::start(lexer* p, fdm* a, ghostcell* pgc)
+{    
+    inifdm(p,a,pgc);
+    nodecalc(p,a);
+    maxcoor(p,a,pgc);
+    paraini(p,a,pgc);
     
     p->phimean=p->F56;
     
     if(p->F60>-1.0e20)
-    p->phimean=p->F60;
-        
-
-	
-	if(p->F40>0)
-	iniphi(a,p,pgc);
-
-	if(p->F80>0 && p->F80<4)
-	inivof(a,p,pgc);
+        p->phimean=p->F60;
     
-	if(p->F80==4)
-	inivofPLIC(a,p,pgc);  
+    if(p->F40>0)
+        iniphi(p,a,pgc);
 
-	if((p->F70>0 || p->F71>0 ||p->F72>0) && p->F40>0)
-	iniphi_box(p,a,pgc);
+    if(p->F40>0 && (p->F112>0 || p->F113>0))
+        iniphi_wedge(p,a);
 
-	if(p->F70>0 && p->F80>0)
-	inivof_box(p,a,pgc);
-    	
-	//iniphi_surfarea(p,a,pgc);
+
+    if(p->F80>0 && p->F80<4)
+        inivof(a,p,pgc);
+    
+    if(p->F80==4)
+        inivofPLIC(a,p,pgc);
+
+    if((p->F70>0 || p->F71>0 ||p->F72>0) && p->F40>0)
+        iniphi_box(p,a,pgc);
+
+    if(p->F40>0)
+        iniphi_fields(p,a,pgc);
+
+    if(p->F70>0 && p->F80>0)
+        inivof_box(p,a,pgc);
 
 	if(p->S10>0 || p->toporead==1)
 	topoini(p,a,pgc);
@@ -73,94 +73,94 @@ void initialize::start(fdm* a, lexer* p, ghostcell* pgc)
 	pgc->flagbase(p,a);
 }
 
-void initialize::inifdm(fdm* a, lexer* p, ghostcell* pgc)
-{	
-		ULOOP
-		a->u(i,j,k)=0.0;
+void initialize::inifdm(lexer* p, fdm* a, ghostcell* pgc)
+{
+    ULOOP
+        a->u(i,j,k)=0.0;
 
-		VLOOP
-		a->v(i,j,k)=0.0;
+    VLOOP
+        a->v(i,j,k)=0.0;
 
-		WLOOP
+    WLOOP
         a->w(i,j,k)=0.0;
 
-	LOOP
-	{
-		a->F(i,j,k)=0.0;
-		a->G(i,j,k)=0.0;
-		a->H(i,j,k)=0.0;
+    LOOP
+    {
+        a->F(i,j,k)=0.0;
+        a->G(i,j,k)=0.0;
+        a->H(i,j,k)=0.0;
 
-		a->press(i,j,k)=p->I55;
-        
+        a->press(i,j,k)=p->I55;
+
         a->Fi(i,j,k)=0.0;
 
-		a->ro(i,j,k)=p->W1;
-		a->visc(i,j,k)=p->W2;
-		a->eddyv(i,j,k)=0.0;
-		a->phi(i,j,k)=1.0;
+        a->ro(i,j,k)=p->W1;
+        a->visc(i,j,k)=p->W2;
+        a->eddyv(i,j,k)=0.0;
+        a->phi(i,j,k)=1.0;
 
-		a->conc(i,j,k)=0.0;
-	}
-
-	ALOOP
-    {
-	a->fb(i,j,k)=1.0;
-    a->topo(i,j,k)=1.0;
-    a->porosity(i,j,k)=1.0;
+        a->conc(i,j,k)=0.0;
     }
 
-	pgc->start4(p,a->ro,1);
+    ALOOP
+    {
+        a->fb(i,j,k)=1.0;
+        a->topo(i,j,k)=1.0;
+        a->porosity(i,j,k)=1.0;
+    }
+
     pgc->start4(p,a->ro,1);
-	pgc->start4(p,a->visc,1);
-	pgc->start4(p,a->eddyv,1);
+    pgc->start4(p,a->ro,1);
+    pgc->start4(p,a->visc,1);
+    pgc->start4(p,a->eddyv,1);
     pgc->start4a(p,a->porosity,1);
-	pgc->start4a(p,a->press,1);
-	pgc->start4a(p,a->fb,150);
-	pgc->start4a(p,a->topo,150);
-	pgc->gcparacox(p,a->fb,150);
+    pgc->start4a(p,a->press,1);
+    pgc->start4a(p,a->fb,150);
+    pgc->start4a(p,a->topo,150);
+    pgc->gcparacox(p,a->fb,150);
     pgc->start4(p,a->phi,50);
 }
 
-void initialize::nodecalc(fdm* a, lexer* p)
+void initialize::nodecalc(lexer* p, fdm* a)
 {
-	int count=0;
-	p->pointnum=0;
-	p->cellnum=0;
-	i=0;
-    
-    // 3D
-	TPLOOP
-	{
-	++count;
-	++p->pointnum;
-	a->nodeval(i,j,k)=count;
-	}
+    int count=0;
+    p->pointnum=0;
+    p->cellnum=0;
+    i=0;
 
-	LOOP
-	++p->cellnum;
-    
+    // 3D
+    TPLOOP
+    {
+        ++count;
+        ++p->pointnum;
+        a->nodeval(i,j,k)=count;
+    }
+
     LOOP
-    ++p->tpcellnum;
+    {
+        ++p->cellnum;
+        ++p->tpcellnum;
+    }
     
     // 2D
     count=0;
     TPSLICELOOP
-	{
-	++count;
-	++p->pointnum2D;
-	a->nodeval2D(i,j)=count;
+    {
+        ++count;
+        ++p->pointnum2D;
+        a->nodeval2D(i,j)=count;
     }
 }
 
-void initialize::maxcoor(fdm* a, lexer* p, ghostcell* pgc)
+void initialize::maxcoor(lexer* p, fdm* a, ghostcell* pgc)
 {
-p->maxlength=-1.0e9;
-p->xcoormax=-1.0e9;
-p->xcoormin=1.0e9;
-p->ycoormax=-1.0e9;
-p->ycoormin=1.0e9;
-p->zcoormax=-1.0e9;
-p->zcoormin=1.0e9;
+    p->maxlength=-1.0e9;
+    p->xcoormax=-1.0e9;
+    p->xcoormin=1.0e9;
+    p->ycoormax=-1.0e9;
+    p->ycoormin=1.0e9;
+    p->zcoormax=-1.0e9;
+    p->zcoormin=1.0e9;
 
     LOOP
     {
@@ -170,24 +170,24 @@ p->zcoormin=1.0e9;
         p->ycoormin = MIN(p->ycoormin,p->YN[JP]);
         p->zcoormax = MAX(p->zcoormax,p->ZN[KP1]);
         p->zcoormin = MIN(p->zcoormin,p->ZN[KP]);
-     }
+    }
 
-     p->maxlength=MAX(p->maxlength,p->xcoormax-p->xcoormin);
-     p->maxlength=MAX(p->maxlength,p->ycoormax-p->ycoormin);
-     p->maxlength=MAX(p->maxlength,p->zcoormax-p->zcoormin);
+    p->maxlength=MAX(p->maxlength,p->xcoormax-p->xcoormin);
+    p->maxlength=MAX(p->maxlength,p->ycoormax-p->ycoormin);
+    p->maxlength=MAX(p->maxlength,p->zcoormax-p->zcoormin);
 
-     p->maxlength=pgc->globalmax(p->maxlength);
-	 
-	 p->xcoormax=pgc->globalmax(p->xcoormax);
-	 p->ycoormax=pgc->globalmax(p->ycoormax);
-	 p->zcoormax=pgc->globalmax(p->zcoormax);
-	 
-	 p->xcoormin=pgc->globalmin(p->xcoormin);
-	 p->ycoormin=pgc->globalmin(p->ycoormin);
-	 p->zcoormin=pgc->globalmin(p->zcoormin);
-	 
-	 if(p->F42>=0.0)
-	 p->maxlength = p->F42;
+    p->maxlength=pgc->globalmax(p->maxlength);
+    
+    p->xcoormax=pgc->globalmax(p->xcoormax);
+    p->ycoormax=pgc->globalmax(p->ycoormax);
+    p->zcoormax=pgc->globalmax(p->zcoormax);
+    
+    p->xcoormin=pgc->globalmin(p->xcoormin);
+    p->ycoormin=pgc->globalmin(p->ycoormin);
+    p->zcoormin=pgc->globalmin(p->zcoormin);
+    
+    if(p->F42>=0.0)
+        p->maxlength = p->F42;
 }
 
 int initialize::conv(double a)

--- a/src/initialize.h
+++ b/src/initialize.h
@@ -26,8 +26,8 @@ Author: Hans Bihs
 #include"resize.h"
 #include"increment.h"
 
-class fdm;
 class lexer;
+class fdm;
 class ghostcell;
 class turbulence;
 class sediment;
@@ -41,38 +41,36 @@ public:
 	initialize(lexer*);
 	virtual ~initialize();
 
-	void start(fdm*, lexer*, ghostcell*);
+    void start(lexer*,fdm*,ghostcell*);
     void droplet_ini(lexer*,fdm*,ghostcell*);
-	void hydrostatic(lexer*,fdm*,ghostcell*);
-	void iniphi_io(fdm*, lexer*,ghostcell*);
-	void inivof_io(fdm*, lexer*,ghostcell*);
-	void iniphi_surfarea(lexer*,fdm*,ghostcell*);
-	void stateini(lexer*,fdm*,ghostcell*,turbulence*,sediment*);
+    void hydrostatic(lexer*,fdm*,ghostcell*);
+    void iniphi_io(fdm*,lexer*,ghostcell*);
+    void inivof_io(fdm*,lexer*,ghostcell*);
+    void iniphi_surfarea(lexer*,fdm*,ghostcell*);
+    void stateini(lexer*,fdm*,ghostcell*,turbulence*,sediment*);
     void inipsi(lexer*,fdm*,ghostcell*);
 
 private:
-	void inifdm(fdm*, lexer*, ghostcell*);
-	void iniphi(fdm*, lexer*,ghostcell*);
-	void iniphi_box(lexer*,fdm*,ghostcell*);	
-	void inivof(fdm*, lexer*,ghostcell*);
-	void inivof_box(lexer*,fdm*,ghostcell*);
-	void inivofPLIC(fdm*, lexer*,ghostcell*);
-	void bcwall_check(fdm*,lexer*);
-	void nodecalc(fdm*, lexer*);
-	void faceneighbors(lexer*,fdm*);
-	void maxcoor(fdm*, lexer*,ghostcell*);
-	void paraini(lexer*, fdm*,ghostcell*);
-	void pressini(lexer*,fdm*,ghostcell*);
-	void topoini(lexer*,fdm*,ghostcell*);
+    void inifdm(lexer*,fdm*,ghostcell*);
+    void iniphi(lexer*,fdm*,ghostcell*);
+    void iniphi_box(lexer*,fdm*,ghostcell*);
+    void iniphi_wedge(lexer*,fdm*);
+    void iniphi_fields(lexer*,fdm*,ghostcell*);
+    void inivof(fdm*,lexer*,ghostcell*);
+    void inivof_box(lexer*,fdm*,ghostcell*);
+    void inivofPLIC(fdm*,lexer*,ghostcell*);
+    void nodecalc(lexer*,fdm*);
+    void maxcoor(lexer*,fdm*,ghostcell*);
+    void paraini(lexer*,fdm*,ghostcell*);
+    void pressini(lexer*,fdm*,ghostcell*);
+    void topoini(lexer*,fdm*,ghostcell*);
     
-	int conv(double);
+    int conv(double);
 
-	const double smallnum;
-	double epsi;
+    double epsi;
 
-	int n,q,iend,kend;
-	double deltax;
-	double H;
+    int n,q,iend,kend;
+    double H;
 };
 
 #endif

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -426,7 +426,9 @@ public:
     int F80,F85;
     double F84;
     int F112;
-    double F112_xs,F112_xe,F112_ys,F112_ye,F112_zs,F112_ze;
+    double *F112_xs,*F112_xe,*F112_ys,*F112_ye,*F112_zs,*F112_ze;
+    int F113;
+    double *F113_xs,*F113_xe,*F113_ys,*F113_ye,*F113_zs,*F113_ze;
     
     int F300,F305,F310,F350;
 	double F321,F322,F323,F360,F361,F362;

--- a/src/lexer_controlfill_recv.cpp
+++ b/src/lexer_controlfill_recv.cpp
@@ -771,18 +771,8 @@ void lexer::ctrlrecv()
     ii++;
     F112 = ictrl[ii];
     ii++;
-    F112_xs = dctrl[dd];
-    dd++;
-    F112_xe = dctrl[dd];
-    dd++;
-    F112_ys = dctrl[dd];
-    dd++;
-    F112_ye = dctrl[dd];
-    dd++;
-    F112_zs = dctrl[dd];
-    dd++;
-    F112_ze = dctrl[dd];
-    dd++;
+    F113 = ictrl[ii];
+    ii++;
     F150 = ictrl[ii];
     ii++;
     F151 = ictrl[ii];
@@ -2330,6 +2320,30 @@ void lexer::ctrlrecv()
 	Darray(F72_h,F72);  
 	}
 
+    if(F112>0)
+    {
+    Darray(F112_xs,F112);
+    Darray(F112_xe,F112);
+
+    Darray(F112_ys,F112);
+    Darray(F112_ye,F112);
+
+    Darray(F112_zs,F112);
+    Darray(F112_ze,F112);
+    }
+
+    if(F113>0)
+    {
+    Darray(F113_xs,F113);
+    Darray(F113_xe,F113);
+
+    Darray(F113_ys,F113);
+    Darray(F113_ye,F113);
+
+    Darray(F113_zs,F113);
+    Darray(F113_ze,F113);
+    }
+
     if(F369>0)
 	{
 	Darray(F369_x,F369);   
@@ -3462,7 +3476,39 @@ void lexer::ctrlrecv()
     dd++;
     }
 
-for(n=0;n<F369;++n)
+    for(n=0;n<F112;++n)
+    {
+    F112_xs[n] = dctrl[dd];
+    dd++;
+    F112_xe[n] = dctrl[dd];
+    dd++;
+    F112_ys[n] = dctrl[dd];
+    dd++;
+    F112_ye[n] = dctrl[dd];
+    dd++;
+    F112_zs[n] = dctrl[dd];
+    dd++;
+    F112_ze[n] = dctrl[dd];
+    dd++;
+    }
+
+    for(n=0;n<F113;++n)
+    {
+    F113_xs[n] = dctrl[dd];
+    dd++;
+    F113_xe[n] = dctrl[dd];
+    dd++;
+    F113_ys[n] = dctrl[dd];
+    dd++;
+    F113_ye[n] = dctrl[dd];
+    dd++;
+    F113_zs[n] = dctrl[dd];
+    dd++;
+    F113_ze[n] = dctrl[dd];
+    dd++;
+    }
+
+    for(n=0;n<F369;++n)
     {
     F369_x[n] = dctrl[dd];
     dd++;

--- a/src/lexer_controlfill_send.cpp
+++ b/src/lexer_controlfill_send.cpp
@@ -775,18 +775,8 @@ void lexer::ctrlsend()
     ii++;
     ictrl[ii] = F112;
     ii++;
-    dctrl[dd] = F112_xs;
-    dd++;
-    dctrl[dd] = F112_xe;
-    dd++;
-    dctrl[dd] = F112_ys;
-    dd++;
-    dctrl[dd] = F112_ye;
-    dd++;
-    dctrl[dd] = F112_zs;
-    dd++;
-    dctrl[dd] = F112_ze;
-    dd++;
+    ictrl[ii] = F113;
+    ii++;
     ictrl[ii] = F150;
 	ii++;
 	ictrl[ii] = F151;
@@ -2541,6 +2531,38 @@ void lexer::ctrlsend()
 	dd++;
     dctrl[dd] = F72_h[n];
 	dd++;
+    }
+
+    for(n=0;n<F112;++n)
+    {
+    dctrl[dd] = F112_xs[n];
+    dd++;
+    dctrl[dd] = F112_xe[n];
+    dd++;
+    dctrl[dd] = F112_ys[n];
+    dd++;
+    dctrl[dd] = F112_ye[n];
+    dd++;
+    dctrl[dd] = F112_zs[n];
+    dd++;
+    dctrl[dd] = F112_ze[n];
+    dd++;
+    }
+
+    for(n=0;n<F113;++n)
+    {
+    dctrl[dd] = F113_xs[n];
+    dd++;
+    dctrl[dd] = F113_xe[n];
+    dd++;
+    dctrl[dd] = F113_ys[n];
+    dd++;
+    dctrl[dd] = F113_ye[n];
+    dd++;
+    dctrl[dd] = F113_zs[n];
+    dd++;
+    dctrl[dd] = F113_ze[n];
+    dd++;
     }
 
     for(n=0;n<F369;++n)

--- a/src/partres_move_RK2.cpp
+++ b/src/partres_move_RK2.cpp
@@ -36,11 +36,6 @@ void partres::move_RK2(lexer *p, fdm *a, ghostcell *pgc, sediment_fdm *s, turbul
     stress_tensor(p,pgc,s);
     stress_gradient(p,a,pgc,s);
     
-    ALOOP
-    a->test(i,j,k) = cellSum(i,j,k)/P.ParcelFactor;
-    //a->test(i,j,k) = Ts(i,j,k);
-   // a->test(i,j,k) = rf(p,p->pos_x(),p->pos_y());
-    //a->test(i,j,k) = (Tau(i,j,k+1) - Tau(i,j,k-1))/(p->DZP[KM1]+p->DZP[KP]);
     
     for(n=0;n<P.index;++n)
     if(P.Flag[n]==ACTIVE)

--- a/src/ptf_RK3.cpp
+++ b/src/ptf_RK3.cpp
@@ -214,8 +214,6 @@ void ptf_RK3::ini(lexer *p, fdm *a, ghostcell *pgc, ioflow *pflow, reini *preini
     
     pgc->gcsl_start4(p,a->eta,50);
     
-    FLUIDLOOP
-    a->test(i,j,k) = a->Fifsf(i,j);
     
     pfsfupdate->velcalc(p,a,pgc,a->Fi);
 }

--- a/src/read_control.cpp
+++ b/src/read_control.cpp
@@ -1019,8 +1019,10 @@ void lexer::read_control()
                 case 85: control>>F85;
                          clear(c,numint);
                          break;
-                case 112: control>>F112_xs>>F112_xe>>F112_ys>>F112_ye>>F112_zs>>F112_ze;
-                         F112=1;
+                case 112: ++F112;
+                         clear(c,numint);
+                         break;
+                case 113: ++F113;
                          clear(c,numint);
                          break;
                 case 150: control>>F150;
@@ -2698,6 +2700,24 @@ void lexer::read_control()
 	Darray(F72_ye,F72);
 
 	Darray(F72_h,F72);
+
+    Darray(F112_xs,F112);
+    Darray(F112_xe,F112);
+
+    Darray(F112_ys,F112);
+    Darray(F112_ye,F112);
+
+    Darray(F112_zs,F112);
+    Darray(F112_ze,F112);
+
+    Darray(F113_xs,F113);
+    Darray(F113_xe,F113);
+
+    Darray(F113_ys,F113);
+    Darray(F113_ye,F113);
+
+    Darray(F113_zs,F113);
+    Darray(F113_ze,F113);
     
     if(F369>0)
 	{
@@ -3162,6 +3182,8 @@ void lexer::read_control()
 	int countF70=0;
 	int countF71=0;
 	int countF72=0;
+    int countF112=0;
+    int countF113=0;
     int countF369=0;
 	int countF370=0;
 	int countF371=0;
@@ -3410,8 +3432,16 @@ void lexer::read_control()
 						 break;
 				case 72: control>>F72_xs[countF72]>>F72_xe[countF72]>>F72_ys[countF72]>>F72_ye[countF72]>>F72_h[countF72];
                         ++countF72;
-						 clear(c,numint);
-						 break;
+                         clear(c,numint);
+                         break;
+                case 112: control>>F112_xs[countF112]>>F112_xe[countF112]>>F112_ys[countF112]>>F112_ye[countF112]>>F112_zs[countF112]>>F112_ze[countF112];
+                        ++countF112;
+                        clear(c,numint);
+                        break;
+                case 113: control>>F113_xs[countF113]>>F113_xe[countF113]>>F113_ys[countF113]>>F113_ye[countF113]>>F113_zs[countF113]>>F113_ze[countF113];
+                        ++countF113;
+                        clear(c,numint);
+                        break;
                 case 369: control>>F369_x[countF369]>>F369_z[countF369]>>F369_a[countF369]>>F369_s[countF369]>>F369_l[countF369]>>F369_v[countF369];
                         ++countF369;
 						 clear(c,numint);

--- a/src/vtr3D.cpp
+++ b/src/vtr3D.cpp
@@ -558,13 +558,6 @@ void vtr3D::print3D(fdm* a,lexer* p,ghostcell* pgc, turbulence *pturb, heat *phe
 	++n;
 	}
 
-    offset[n]=offset[n-1]+4*(p->cellnum)+4;
-	++n;
-    offset[n]=offset[n-1]+4*(p->cellnum)+4;
-	++n;
-    offset[n]=offset[n-1]+4*(p->cellnum)+4;
-	++n;
-
 	// end scalars
 	//---------------------------------------------
 
@@ -695,14 +688,6 @@ void vtr3D::print3D(fdm* a,lexer* p,ghostcell* pgc, turbulence *pturb, heat *phe
 	}
     result<<"</PointData>"<<endl;
 
-	result<<"<CellData>"<<endl;
-    result<<"<DataArray type=\"Float32\" Name=\"topoSum\"  format=\"appended\" offset=\""<<offset[n]<<"\" />"<<endl;
-    ++n;
-    result<<"<DataArray type=\"Float32\" Name=\"bedChange\"  format=\"appended\" offset=\""<<offset[n]<<"\" />"<<endl;
-    ++n;
-	result<<"<DataArray type=\"Float32\" Name=\"erosion/depositionion\"  format=\"appended\" offset=\""<<offset[n]<<"\" />"<<endl;
-    ++n;
-	result<<"</CellData>"<<endl;
     result<<"<Coordinates>"<<endl;
 	result<<"<DataArray type=\"Float32\" Name=\"X\" format=\"appended\" offset=\""<<offset[n]<<"\"/>"<<endl;
 	n++;
@@ -924,29 +909,6 @@ void vtr3D::print3D(fdm* a,lexer* p,ghostcell* pgc, turbulence *pturb, heat *phe
 	ffn=float(p->ipol4_a(a->walld));
 	result.write((char*)&ffn, sizeof (float));
 	}
-	}
-
-    // debugOutput for sedPart
-    iin=4*(p->cellnum);
-	result.write((char*)&iin, sizeof (int));
-	BASEREVLOOP
-	{
-	ffn=float(a->test(i,j,k));
-	result.write((char*)&ffn, sizeof (float));
-	}
-    iin=4*(p->cellnum);
-	result.write((char*)&iin, sizeof (int));
-	BASEREVLOOP
-	{
-	ffn=float(a->fb(i,j,k));
-	result.write((char*)&ffn, sizeof (float));
-	}
-    iin=4*(p->cellnum);
-	result.write((char*)&iin, sizeof (int));
-	BASEREVLOOP
-	{
-	ffn=float(a->vof(i,j,k));
-	result.write((char*)&ffn, sizeof (float));
 	}
 
 	// Coordinates

--- a/src/vtr3D_pvtr.cpp
+++ b/src/vtr3D_pvtr.cpp
@@ -130,11 +130,6 @@ void vtr3D::pvtr(fdm* a, lexer* p, ghostcell* pgc, turbulence *pturb, heat *phea
 	result<<"<PDataArray type=\"Float32\" Name=\"walldist\"/>"<<endl;
 
 	result<<"</PPointData>"<<endl;
-	result<<"<PCellData>"<<endl;
-    result<<"<PDataArray type=\"Float32\" Name=\"topoSum\"/>"<<endl;
-    result<<"<PDataArray type=\"Float32\" Name=\"bedChange\"/>"<<endl;
-	result<<"<PDataArray type=\"Float32\" Name=\"erosion/depositionion\"/>"<<endl;
-	result<<"</PCellData>"<<endl;
 
 	result<<"<PCoordinates>"<<endl;
     result<<"<PDataArray type=\"Float32\" Name=\"X\" NumberOfComponents=\"1\" format=\"appended\"/>"<<endl;


### PR DESCRIPTION
### Fluid_update 2ee75ea
- Added flagsf4 check to volume calculation
- Moved epsi computation to constructor which was executed in each iteration with always the same result
- Removed unnecessary brackets and whitespaces in implementation
- Changed whitespaces in header
- Removed unused forward-declarations from base class
- Changed whitespaces in base class
### Initialize ae92d46
- Removed explicit constructor & destructor as they were empty -> Caused change in driver
- Reordered starts parameters to match typical order -> Caused change in driver
- Reordered parameters of other private non-VOF related methods to match typical order
- Removed unused class members
- Removed zero-initializers from inifem as the fields are zero-initialized
- Merged loops
- Changed whitespaces
- Changed F112 to array type -> Caused changes to lexer
- Added F113 for y direction slopes -> Caused changes to lexer
- Moved ro and visc ini to their own method
### Test removal 43a74ed
- Needed test field to check if changes worked -> Removed all existing calls to set it
- Also removed PARTRES debug printing from VTR printer