### PR TITLE
DockerUpdate by estilmk47

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,53 @@
-# ubuntu base image
+# Base Ubuntu image
 FROM ubuntu:latest
 
-# install required dependencies
-RUN apt-get update
-RUN apt-get -y install git cmake build-essential gfortran mpich
+# Install required dependencies
+RUN apt-get update && apt-get install -y \
+    git cmake build-essential gfortran wget \
+    && rm -rf /var/lib/apt/lists/*  
+    # Clean up to reduce image size
 
-# clone Hypre from Github and install it
-RUN git clone https://github.com/hypre-space/hypre.git
-RUN cd hypre/src && ./configure --prefix=/usr/local/hypre && make all -j 8 && make install
-# adding paths for hypre
-RUN export PATH=/usr/local/hypre/include:/usr/local/hypre/lib:$PATH
+# Install OpenMPI
+WORKDIR /opt
+RUN wget https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-5.0.6.tar.gz && \
+    tar -xvzf openmpi-5.0.6.tar.gz && \
+    cd openmpi-5.0.6 && ./configure --prefix=/usr/local/openmpi && make -j $(nproc) all && make install
 
-# clone DIVEMesh and REEF3D from Github and make files
-RUN git clone https://github.com/REEF3D/DIVEMesh.git
-RUN cd DIVEMesh && make -j 8 && cd ..
-RUN git clone https://github.com/REEF3D/REEF3D.git
-RUN cd REEF3D && make -j 8
+# Set OpenMPI Environment Variables
+ENV PATH="/usr/local/openmpi/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/usr/local/openmpi/lib:${LD_LIBRARY_PATH}"
+# Set OpenMPI and PMIx environment variables
+ENV OMPI_ALLOW_RUN_AS_ROOT=1
+ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+ENV PMIX_MCA_pcompress_base_silence_warning=1
 
-# create simulations folder and copy binaries into working folder
-RUN mkdir simulations
-RUN echo "export PATH=/simulations:$PATH && cp ./DIVEMesh/bin/DiveMESH ./simulations && cp ./REEF3D/bin/REEF3D ./simulations && cd simulations" >> ~/.bashrc
+
+# Clone and Install Hypre
+WORKDIR /opt
+RUN git clone https://github.com/hypre-space/hypre.git && \
+    cd hypre/src && ./configure --prefix=/usr/local/hypre && make -j $(nproc) all && make install
+
+# Set Hypre Environment Variables
+ENV PATH="/usr/local/hypre/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/usr/local/hypre/lib:${LD_LIBRARY_PATH}"
+
+# Clone and Build DIVEMesh
+WORKDIR /opt
+RUN git clone https://github.com/REEF3D/DIVEMesh.git && \
+    cd DIVEMesh && make -j $(nproc)
+
+# Clone and Build REEF3D
+WORKDIR /opt
+RUN git clone https://github.com/REEF3D/REEF3D.git && \
+    cd REEF3D && make -j $(nproc)
+
+# Create simulations folder and copy binaries
+RUN echo "mkdir -p /simulations && cp /opt/DIVEMesh/bin/DiveMESH /simulations && cp /opt/REEF3D/bin/REEF3D /simulations" >> ~/.bashrc
+
+# Set PATH for simulations
+ENV PATH="/simulations:${PATH}"
+
+# Set working directory for container
+WORKDIR /simulations
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
Updated MPI version
Build now utilizes the number of available CPU cores instead of the previously hardcoded value of 8.
Cleanup on Line 7 to reduce the image size.

Co-authored-by: estilmk47 <estil@kragebakk.no>