### PR TITLE
Initial print for mooringlines & nets

### DIFF
--- a/src/6DOF_obj_ini_cfd.cpp
+++ b/src/6DOF_obj_ini_cfd.cpp
@@ -99,13 +99,6 @@ void sixdof_obj::initialize_cfd(lexer *p, fdm *a, ghostcell *pgc, vector<net*>& 
      pgc->start3(p,a->fbh3,12);
      pgc->start4(p,a->fbh4,40);
 
-    // Print initial body 
-    if(p->X50==1)
-    print_vtp(p,pgc);
-    
-    if(p->X50==2)
-    print_stl(p,pgc);
-
 	// Mooring
 	if(p->X310==0)
 	{
@@ -207,6 +200,12 @@ void sixdof_obj::initialize_cfd(lexer *p, fdm *a, ghostcell *pgc, vector<net*>& 
             pnet[ii]->initialize(p,a,pgc);
 		}
     }
+
+    // Print initial body 
+    if(p->X50==1)
+        print_vtp(p,pgc);
+    else if(p->X50==2)
+        print_stl(p,pgc);
     
     // ghostcell update
     pgc->gcdf_update(p,a);

--- a/src/mooring_Catenary_ini.cpp
+++ b/src/mooring_Catenary_ini.cpp
@@ -62,4 +62,6 @@ void mooring_Catenary::initialize(lexer *p, ghostcell *pgc)
     curr_time = 0.0;
     breakTension = p->X314 > 0 ? p->X314_T[line]: 0.0;
     breakTime = p->X315 > 0 ? p->X315_t[line]: 0.0;
+
+    print(p);
 }

--- a/src/mooring_Spring.cpp
+++ b/src/mooring_Spring.cpp
@@ -40,6 +40,7 @@ void mooring_Spring::initialize(lexer *p, ghostcell *pgc)
    
 	k = p->X312_k[line];
     T0 = p->X312_T0[line];
+    T = T0;
 
 	if(p->mpirank==0)
 	{
@@ -56,6 +57,8 @@ void mooring_Spring::initialize(lexer *p, ghostcell *pgc)
     curr_time = 0.0;
     breakTension = p->X314 > 0 ? p->X314_T[line]: 0.0;
     breakTime = p->X315 > 0 ? p->X315_t[line]: 0.0;
+
+    print(p);
 }
 
 

--- a/src/mooring_barQuasiStatic_ini.cpp
+++ b/src/mooring_barQuasiStatic_ini.cpp
@@ -119,6 +119,8 @@ void mooring_barQuasiStatic::initialize(lexer *p, ghostcell *pgc)
     curr_time = 0.0;
     breakTension = p->X314 > 0 ? p->X314_T[line]: 0.0;
     breakTime = p->X315 > 0 ? p->X315_t[line]: 0.0;
+
+    print(p,pgc);
 }
 
 

--- a/src/mooring_dynamic_ini.cpp
+++ b/src/mooring_dynamic_ini.cpp
@@ -92,6 +92,8 @@ void mooring_dynamic::initialize(lexer *p, ghostcell *pgc)
     broken = false;
     breakTension = p->X314 > 0 ? p->X314_T[line]: 0.0;
     breakTime = p->X315 > 0 ? p->X315_t[line]: 0.0;
+
+    print(p);
 }
 
 void mooring_dynamic::ini_parallel(lexer *p, ghostcell *pgc)

--- a/src/net_barQuasiStatic.cpp
+++ b/src/net_barQuasiStatic.cpp
@@ -58,6 +58,8 @@ void net_barQuasiStatic::initialize(lexer *p, fdm *a, ghostcell *pgc)
     
     //- Update porous zone
     vransCoupling(p,a,pgc);
+
+    print(p);
 }
 
 

--- a/src/net_sheet_print.cpp
+++ b/src/net_sheet_print.cpp
@@ -32,7 +32,7 @@ void net_sheet::print(lexer *p)
 	int num=0;
 	
 	if(p->P15==1)
-    num = p->printcount_sixdof-1;
+    num = p->printcount_sixdof;
 
     if(p->P15==2)
     num = p->count;


### PR DESCRIPTION
Added initial print for all mooring types
Fixed inital printing for net types
Moved 6DOF_obj printing to end of function so that the mooring and net printing works as intended