### PR TITLE
sflow_print_probe_da - reduce number of concurrent filestreams

### DIFF
--- a/src/sflow_print_probe_da.cpp
+++ b/src/sflow_print_probe_da.cpp
@@ -58,39 +58,20 @@ sflow_print_probe_da::sflow_print_probe_da(lexer *p, fdm2D *b, ghostcell *pgc) :
 		pout[n]<<endl<<endl;
 		
 		pout[n]<<"t \t Um \t Vm \t Wm \t Pm \t eta"<<endl;
-		}
+        pout[n].close();
+        }
     }
 	
     ini_location(p,b,pgc);
-    
-    // close
-    if(p->mpirank==0)
-    for(n=0;n<probenum;++n)
-    pout[n].close();
 }
 
 sflow_print_probe_da::~sflow_print_probe_da()
 {
-	for(n=0;n<probenum;++n)
-    pout[n].close();
 }
 
 void sflow_print_probe_da::start(lexer *p, fdm2D *b, ghostcell *pgc)
 {
 	double xp,yp;
-    
-    
-    
-    // open
-    if(p->mpirank==0)
-    for(n=0;n<probenum;++n)
-    {
-    sprintf(name,"./REEF3D_SFLOW_ProbePoint/REEF3D-SFLOW-Probe-Point-%i.dat",n+1);
-        
-    pout[n].open(name, std::ofstream::out | std::ofstream::app);
-    }
-	
-    
     // find values and write
 	for(n=0;n<probenum;++n)
 	{
@@ -114,14 +95,14 @@ void sflow_print_probe_da::start(lexer *p, fdm2D *b, ghostcell *pgc)
 	pval=pgc->globalmax(pval);
     eval=pgc->globalmax(eval);
 	
-	if(p->mpirank==0)
-	pout[n]<<setprecision(9)<<p->simtime<<" \t "<<uval<<" \t "<<vval<<" \t "<<wval<<" \t "<<pval<<" \t "<<eval<<endl;
-	}
-    
-    // close
-    if(p->mpirank==0)
-    for(n=0;n<probenum;++n)
-    pout[n].close();
+        if(p->mpirank==0)
+        {
+            sprintf(name,"./REEF3D_SFLOW_ProbePoint/REEF3D-SFLOW-Probe-Point-%i.dat",n+1);
+            pout[n].open(name, std::ofstream::out | std::ofstream::app);
+            pout[n]<<setprecision(9)<<p->simtime<<" \t "<<uval<<" \t "<<vval<<" \t "<<wval<<" \t "<<pval<<" \t "<<eval<<endl;
+            pout[n].close();
+        }
+    }
 }
 
 void sflow_print_probe_da::write(lexer *p, fdm2D *b, ghostcell *pgc)


### PR DESCRIPTION
Solved problem of limited number of file descriptors = 256, therefore limited number of possible point probes.
Updated sflow_print_probe_da so that open file streams are closed after writing.
Therefore making it possible to have unlimited number of point probes.