### PR TITLE
Applied custom 6DOF fixes for heave, pitch, and roll

### DIFF
--- a/src/6DOF_motion-file.cpp
+++ b/src/6DOF_motion-file.cpp
@@ -70,21 +70,21 @@ void sixdof_motionext_file::ini(lexer *p, ghostcell *pgc)
 void sixdof_motionext_file::motionext_trans(lexer *p, ghostcell *pgc, Eigen::Vector3d& dp_, Eigen::Vector3d& dc_)
 {
     // find correct time step
-    if((p->simtime>data[timecount][0]))
-    timecount_old=timecount;
-    
-	while(p->simtime>data[timecount][0])
-	++timecount;
+    if (p->simtime <= te)
+    {
+        if(p->simtime>data[timecount][0])
+        timecount_old=timecount;
+        
+        while(p->simtime>data[timecount][0])
+        ++timecount;
+    }
     
     
     if(p->X11_u==2)
     {
         Uext = 0.0;
         
-        if(timecount == timecount_old)
-        Uext = 0.0;
-        
-        else if(p->simtime>=ts && p->simtime<=te && timecount<ptnum && timecount_old<ptnum)
+        if(p->simtime>=ts && p->simtime<=te)
         Uext = (data[timecount][2]-data[timecount_old][2])/(data[timecount][0]-data[timecount_old][0]);
         
         dp_(0) = 0.0;
@@ -95,10 +95,7 @@ void sixdof_motionext_file::motionext_trans(lexer *p, ghostcell *pgc, Eigen::Vec
     {
         Vext = 0.0;
         
-        if(timecount == timecount_old)
-        Vext = 0.0;
-        
-        else if(p->simtime>=ts && p->simtime<=te && timecount<ptnum && timecount_old<ptnum)
+        if(p->simtime>=ts && p->simtime<=te)
         Vext = (data[timecount][1]-data[timecount_old][1])/(data[timecount][0]-data[timecount_old][0]);
         
         dp_(1) = 0.0;
@@ -109,10 +106,7 @@ void sixdof_motionext_file::motionext_trans(lexer *p, ghostcell *pgc, Eigen::Vec
     {
         Wext = 0.0;
         
-        if(timecount == timecount_old)
-        Wext = 0.0;
-        
-        else if(p->simtime>=ts && p->simtime<=te && timecount<ptnum && timecount_old<ptnum)
+        if(p->simtime>=ts && p->simtime<=te)
         Wext = (data[timecount][2]-data[timecount_old][2])/(data[timecount][0]-data[timecount_old][0]);
         
         dp_(2) = 0.0;
@@ -126,7 +120,7 @@ void sixdof_motionext_file::motionext_rot(lexer *p, Eigen::Vector3d& dh_, Eigen:
     {
         Pext = 0.0;
         
-        if(p->simtime>=ts && p->simtime<=te && timecount<ptnum-1 && timecount_old<ptnum)
+        if(p->simtime>=ts && p->simtime<=te)
         Pext = (data[timecount][1]-data[timecount_old][1])/(data[timecount][0]-data[timecount_old][0]);
     }
 
@@ -134,7 +128,7 @@ void sixdof_motionext_file::motionext_rot(lexer *p, Eigen::Vector3d& dh_, Eigen:
     {
         Qext = 0.0;
         
-        if(p->simtime>=ts && p->simtime<=te && timecount<ptnum-1 && timecount_old<ptnum)
+        if(p->simtime>=ts && p->simtime<=te)
         Qext = (data[timecount][1]-data[timecount_old][1])/(data[timecount][0]-data[timecount_old][0]);
     }
 
@@ -142,18 +136,23 @@ void sixdof_motionext_file::motionext_rot(lexer *p, Eigen::Vector3d& dh_, Eigen:
     {
         Rext = 0.0;
         
-        if(p->simtime>=ts && p->simtime<=te && timecount<ptnum-1 && timecount_old<ptnum)
+        if(p->simtime>=ts && p->simtime<=te)
         Rext = (data[timecount][1]-data[timecount_old][1])/(data[timecount][0]-data[timecount_old][0]);
     }
     
-    dh_ << 0.0,0.0,0.0;
-    
-    omega_ << Pext*ramp_vel(p), Qext*ramp_vel(p), Rext*ramp_vel(p);
-    
-    h_ = I_*omega_;
-    
+    if(p->X11_p == 2) dh_(0) = 0.0;
+    if(p->X11_q == 2) dh_(1) = 0.0;
+    if(p->X11_r == 2) dh_(2) = 0.0;
 
-    de_ = 0.5*G_.transpose()*I_.inverse()*h_;
+    omega_ = I_.inverse() * h_;
+
+    if(p->X11_p == 2) omega_(0) = Pext*ramp_vel(p);
+    if(p->X11_q == 2) omega_(1) = Qext*ramp_vel(p);
+    if(p->X11_r == 2) omega_(2) = Rext*ramp_vel(p);
+
+    h_ = I_*omega_;
+
+    de_ = 0.5*G_.transpose()*omega_;
 }
 
 double sixdof_motionext_file::ramp_vel(lexer *p)

--- a/src/6DOF_motion-file.cpp
+++ b/src/6DOF_motion-file.cpp
@@ -85,7 +85,7 @@ void sixdof_motionext_file::motionext_trans(lexer *p, ghostcell *pgc, Eigen::Vec
         Uext = 0.0;
         
         if(p->simtime>=ts && p->simtime<=te)
-        Uext = (data[timecount][2]-data[timecount_old][2])/(data[timecount][0]-data[timecount_old][0]);
+        Uext = (data[timecount][1]-data[timecount_old][1])/(data[timecount][0]-data[timecount_old][0]);
         
         dp_(0) = 0.0;
         dc_(0) = Uext*ramp_vel(p);
@@ -96,7 +96,7 @@ void sixdof_motionext_file::motionext_trans(lexer *p, ghostcell *pgc, Eigen::Vec
         Vext = 0.0;
         
         if(p->simtime>=ts && p->simtime<=te)
-        Vext = (data[timecount][1]-data[timecount_old][1])/(data[timecount][0]-data[timecount_old][0]);
+        Vext = (data[timecount][2]-data[timecount_old][2])/(data[timecount][0]-data[timecount_old][0]);
         
         dp_(1) = 0.0;
         dc_(1) = Vext*ramp_vel(p);
@@ -107,7 +107,7 @@ void sixdof_motionext_file::motionext_trans(lexer *p, ghostcell *pgc, Eigen::Vec
         Wext = 0.0;
         
         if(p->simtime>=ts && p->simtime<=te)
-        Wext = (data[timecount][2]-data[timecount_old][2])/(data[timecount][0]-data[timecount_old][0]);
+        Wext = (data[timecount][3]-data[timecount_old][3])/(data[timecount][0]-data[timecount_old][0]);
         
         dp_(2) = 0.0;
         dc_(2) = Wext*ramp_vel(p);
@@ -129,7 +129,7 @@ void sixdof_motionext_file::motionext_rot(lexer *p, Eigen::Vector3d& dh_, Eigen:
         Qext = 0.0;
         
         if(p->simtime>=ts && p->simtime<=te)
-        Qext = (data[timecount][1]-data[timecount_old][1])/(data[timecount][0]-data[timecount_old][0]);
+        Qext = (data[timecount][2]-data[timecount_old][2])/(data[timecount][0]-data[timecount_old][0]);
     }
 
     if(p->X11_r==2)
@@ -137,7 +137,7 @@ void sixdof_motionext_file::motionext_rot(lexer *p, Eigen::Vector3d& dh_, Eigen:
         Rext = 0.0;
         
         if(p->simtime>=ts && p->simtime<=te)
-        Rext = (data[timecount][1]-data[timecount_old][1])/(data[timecount][0]-data[timecount_old][0]);
+        Rext = (data[timecount][3]-data[timecount_old][3])/(data[timecount][0]-data[timecount_old][0]);
     }
     
     if(p->X11_p == 2) dh_(0) = 0.0;
@@ -176,10 +176,10 @@ double sixdof_motionext_file::ramp_draft(lexer *p)
     double f=1.0;
 
     if(p->X205==1 && p->X207==1 && p->simtime>=p->X207_ts && p->simtime<p->X207_te)
-    f = p->simtime/(p->X207_te-p->X207_ts);
+    f = (p->simtime-p->X207_ts)/(p->X207_te-p->X207_ts);
 
     if(p->X205==2 && p->X207==1 && p->simtime>=p->X207_ts && p->simtime<p->X207_te)
-    f = p->simtime/(p->X207_te-p->X207_ts) - (1.0/PI)*sin(PI*(p->simtime/(p->X207_te-p->X207_ts)));
+    f = (p->simtime-p->X207_ts)/(p->X207_te-p->X207_ts) - (1.0/PI)*sin(PI*((p->simtime-p->X207_ts)/(p->X207_te-p->X207_ts)));
 
     if(p->X207==1 && p->simtime<p->X207_ts)
     f=0.0;

--- a/src/6DOF_motion-file_CoG.cpp
+++ b/src/6DOF_motion-file_CoG.cpp
@@ -108,15 +108,12 @@ void sixdof_motionext_file_CoG::motionext_rot(lexer *p, Eigen::Vector3d& dh_, Ei
         if(p->X11_p == 2) dh_(0) = 0.0;
         if(p->X11_q == 2) dh_(1) = 0.0;
         if(p->X11_r == 2) dh_(2) = 0.0;
-        // Extract current real angular velocity from the solver's momentum
         omega_ = I_.inverse() * h_;
 
-        // Override only the prescribed angular velocities
         if(p->X11_p == 2) omega_(0) = 0.0;
         if(p->X11_q == 2) omega_(1) = 0.0;
-        if(p->X11_r == 2) omega_(2) = Rext*ramp_vel(p);
+        if(p->X11_r == 2) omega_(2) = Rext * ramp_vel(p); // Rext is already in rad/s
 
-        // Feed the corrected angular velocity back to the solver
         h_ = I_*omega_;
 
         de_ = 0.5*G_.transpose()*omega_;
@@ -143,10 +140,10 @@ double sixdof_motionext_file_CoG::ramp_draft(lexer *p)
     double f=1.0;
 
     if(p->X205==1 && p->X207==1 && p->simtime>=p->X207_ts && p->simtime<p->X207_te)
-    f = p->simtime/(p->X207_te-p->X207_ts);
+    f = (p->simtime-p->X207_ts)/(p->X207_te-p->X207_ts);
 
     if(p->X205==2 && p->X207==1 && p->simtime>=p->X207_ts && p->simtime<p->X207_te)
-    f = p->simtime/(p->X207_te-p->X207_ts) - (1.0/PI)*sin(PI*(p->simtime/(p->X207_te-p->X207_ts)));
+    f = (p->simtime-p->X207_ts)/(p->X207_te-p->X207_ts) - (1.0/PI)*sin(PI*((p->simtime-p->X207_ts)/(p->X207_te-p->X207_ts)));
 
     if(p->X207==1 && p->simtime<p->X207_ts)
     f=0.0;

--- a/src/6DOF_motion-file_CoG.cpp
+++ b/src/6DOF_motion-file_CoG.cpp
@@ -57,58 +57,69 @@ void sixdof_motionext_file_CoG::ini(lexer *p, ghostcell *pgc)
 void sixdof_motionext_file_CoG::motionext_trans(lexer *p, ghostcell *pgc, Eigen::Vector3d& dp_, Eigen::Vector3d& dc_)
 {
     // find correct time step
-    if((p->simtime>data[timecount][0]))
-    timecount_old=timecount;
-    
-	while(p->simtime>data[timecount][0])
-	++timecount;
+    if (p->simtime <= te)
+    {
+        if(p->simtime>data[timecount][0])
+        timecount_old=timecount;
+        
+        while(p->simtime>data[timecount][0])
+        ++timecount;
+    }
     
     
         Uext = 0.0;
         Vext = 0.0;
         
-        if(timecount == timecount_old)
-        {
-            Uext = 0.0;
-            Vext = 0.0;
-        }
-        else if(p->simtime>=ts && p->simtime<=te && timecount<ptnum && timecount_old<ptnum)
+        if(p->simtime>=ts && p->simtime<=te)
         {
             Uext = (data[timecount][1]-data[timecount_old][1])/(data[timecount][0]-data[timecount_old][0]);
             Vext = (data[timecount][2]-data[timecount_old][2])/(data[timecount][0]-data[timecount_old][0]);
         }
         
-        dp_(0) = 0.0;
-        dc_(0) = Uext*ramp_vel(p);
+        if (p->X11_u == 2)
+        {
+            dp_(0) = 0.0;
+            dc_(0) = Uext*ramp_vel(p);
+        }
 
-        dp_(1) = 0.0;
-        dc_(1) = Vext*ramp_vel(p);
+        if (p->X11_v == 2)
+        {
+            dp_(1) = 0.0;
+            dc_(1) = Vext*ramp_vel(p);
+        }
         
-        dp_(2) = 0.0;
-        dc_(2) = 0.0;
+        if (p->X11_w == 2)
+        {
+            dp_(2) = 0.0;
+            dc_(2) = 0.0;
+        }
 }
 
 void sixdof_motionext_file_CoG::motionext_rot(lexer *p, Eigen::Vector3d& dh_, Eigen::Vector3d& h_, Eigen::Vector4d& de_, Eigen::Matrix<double, 3, 4>&G_,  Eigen::Matrix3d&I_)
 {
         Rext = 0.0;
         
-        if(timecount == timecount_old)
-        {
-            Rext = 0.0;
-        }
-        else if(p->simtime>=ts && p->simtime<=te && timecount<ptnum && timecount_old<ptnum)
+        if(p->simtime>=ts && p->simtime<=te)
         {
             Rext = (data[timecount][3]-data[timecount_old][3])/(data[timecount][0]-data[timecount_old][0]);
         }
     
     
-        dh_ << 0.0,0.0,0.0;
-        
-        omega_ << 0.0, 0.0, Rext*ramp_vel(p);
-        
+        if(p->X11_p == 2) dh_(0) = 0.0;
+        if(p->X11_q == 2) dh_(1) = 0.0;
+        if(p->X11_r == 2) dh_(2) = 0.0;
+        // Extract current real angular velocity from the solver's momentum
+        omega_ = I_.inverse() * h_;
+
+        // Override only the prescribed angular velocities
+        if(p->X11_p == 2) omega_(0) = 0.0;
+        if(p->X11_q == 2) omega_(1) = 0.0;
+        if(p->X11_r == 2) omega_(2) = Rext*ramp_vel(p);
+
+        // Feed the corrected angular velocity back to the solver
         h_ = I_*omega_;
-        
-        de_ = 0.5*G_.transpose()*I_.inverse()*h_;
+
+        de_ = 0.5*G_.transpose()*omega_;
 }
 
 double sixdof_motionext_file_CoG::ramp_vel(lexer *p)

--- a/src/6DOF_motion-file_CoG_read.cpp
+++ b/src/6DOF_motion-file_CoG_read.cpp
@@ -34,43 +34,16 @@ void sixdof_motionext_file_CoG::read_format_1(lexer *p, ghostcell *pgc)
 	
 	sprintf(name,"6DOF_motion.dat");
 
-// open file and count
-	ifstream file(name, ios_base::in);
-	
-	if(!file)
-	cout<<endl<<("no '6DOF_motion.dat' file found")<<endl<<endl;
-
-    
-    count=0;
-	while(!file.eof())
-	{
-        for(qn=0;qn<colnum;++qn)
-        file>>val;
-	++count;
-	}
-	ptnum=count;
-    
-	file.close();
-    
-// allocate
-    p->Darray(data,ptnum,colnum);
-    
-
-// re.open file
-    file.open (name, ios_base::in);
-	
-	if(!file)
-	cout<<endl<<("no '6DOF_motion.dat' file found")<<endl<<endl;
-    
- // read file   
-    rowcount=colcount=0;
-	while(!file.eof())
-	{
-        for(qn=0;qn<colnum;++qn)
-        file>>data[rowcount][qn];
+    try {
+        auto table = readTable(name, colnum);
+        ptnum = table.size();
         
-        ++rowcount;
-	}
+        // copy data directly
+        data = std::move(table);
+    } catch(const std::exception& e) {
+        cout << "Error: " << e.what() << endl;
+        pgc->final(EXIT_FAILURE);
+    }
     
     ts = data[0][0];
     te = data[ptnum-1][0];
@@ -92,7 +65,7 @@ void sixdof_motionext_file_CoG::read_format_1(lexer *p, ghostcell *pgc)
 // convert rotation
     for(qn=0;qn<ptnum;++qn)
     {
-    data[qn][3] = (90.0-data[qn][3])*(PI/180.0);
+    data[qn][3] = data[qn][3]*(PI/180.0);
     }
     
 }

--- a/src/6DOF_motion-file_read.cpp
+++ b/src/6DOF_motion-file_read.cpp
@@ -34,45 +34,16 @@ void sixdof_motionext_file::read_format_1(lexer *p, ghostcell *pgc)
 	
 	sprintf(name,"6DOF_motion.dat");
 
-// open file and count
-	ifstream file(name, ios_base::in);
-	
-	if(!file)
-	cout<<endl<<("no '6DOF_motion.dat' file found")<<endl<<endl;
-
-    
-    count=0;
-	while(!file.eof())
-	{
-        for(qn=0;qn<colnum;++qn)
-        file>>val;
-	++count;
-	}
-	ptnum=count;
-    
-    //cout<<"6DOF MOTION READ "<<count<<endl;
-    
-	file.close();
-    
-// allocate
-    p->Darray(data,ptnum,colnum);
-    
-
-// re.open file
-    file.open (name, ios_base::in);
-	
-	if(!file)
-	cout<<endl<<("no '6DOF_motion.dat' file found")<<endl<<endl;
-    
- // read file   
-    rowcount=colcount=0;
-	while(!file.eof())
-	{
-        for(qn=0;qn<colnum;++qn)
-        file>>data[rowcount][qn];
+    try {
+        auto table = readTable(name, colnum);
+        ptnum = table.size();
         
-        ++rowcount;
-	}
+        // copy data directly
+        data = std::move(table);
+    } catch(const std::exception& e) {
+        cout << "Error: " << e.what() << endl;
+        pgc->final(EXIT_FAILURE);
+    }
     
     ts = data[0][0];
     te = data[ptnum-1][0];

--- a/src/6DOF_motionext.h
+++ b/src/6DOF_motionext.h
@@ -30,6 +30,11 @@ class fdm2D;
 class ghostcell;
 class field;
 #include <Eigen/Dense>
+#include <vector>
+#include <string>
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
 
 using namespace std;
 
@@ -40,6 +45,37 @@ public:
     virtual void motionext_rot(lexer*, Eigen::Vector3d&, Eigen::Vector3d&, Eigen::Vector4d&, Eigen::Matrix<double, 3, 4>&,  Eigen::Matrix3d&)=0;
 
     virtual void ini(lexer*,ghostcell*)=0;
+
+protected:
+    inline std::vector<std::vector<double>> readTable(const std::string& path, size_t M) {
+        std::ifstream file(path);
+        if (!file) {
+            throw std::runtime_error("Could not open file: " + path);
+        }
+
+        std::vector<std::vector<double>> table_data;
+        std::string line;
+
+        while (std::getline(file, line)) {
+            if (line.empty()) continue; // skip blank lines
+
+            std::istringstream iss(line);
+            std::vector<double> row;
+            row.reserve(M);
+            double value;
+            while (iss >> value) {
+                row.push_back(value);
+            }
+
+            if (row.size() != M) {
+                throw std::runtime_error("Row has " + std::to_string(row.size()) +
+                                          " columns, expected " + std::to_string(M));
+            }
+            table_data.push_back(std::move(row));
+        }
+
+        return table_data;
+    }
 };
 
 #endif

--- a/src/6DOF_motionext_CoG.h
+++ b/src/6DOF_motionext_CoG.h
@@ -66,7 +66,7 @@ private:
     int rowcount,colcount;
     int colnum;
     double val;
-    double **data;
+    std::vector<std::vector<double>> data;
     double ts,te;
     int timecount,timecount_old;
     

--- a/src/6DOF_motionext_file.h
+++ b/src/6DOF_motionext_file.h
@@ -66,7 +66,7 @@ private:
     int rowcount,colcount;
     int colnum;
     double val;
-    double **data;
+    std::vector<std::vector<double>> data;
     double ts,te;
     int timecount,timecount_old;
     

--- a/src/6DOF_motionext_fixed.cpp
+++ b/src/6DOF_motionext_fixed.cpp
@@ -69,20 +69,19 @@ void sixdof_motionext_fixed::motionext_trans(lexer *p, ghostcell *pgc, Eigen::Ve
 void sixdof_motionext_fixed::motionext_rot(lexer *p, Eigen::Vector3d& dh_, Eigen::Vector3d& h_, Eigen::Vector4d& de_, Eigen::Matrix<double, 3, 4>&G_,  Eigen::Matrix3d&I_)
 {
 
-    if(p->X11_p==2)
-    omega_(0) = Pext*ramp_vel(p);
-    
-    if(p->X11_q==2)
-    omega_(1) = Qext*ramp_vel(p);
-    
-    if(p->X11_r==2)
-    omega_(2) = Rext*ramp_vel(p);
-    
+    if(p->X11_p == 2) dh_(0) = 0.0;
+    if(p->X11_q == 2) dh_(1) = 0.0;
+    if(p->X11_r == 2) dh_(2) = 0.0;
+
+    omega_ = I_.inverse() * h_;
+
+    if(p->X11_p == 2) omega_(0) = Pext*ramp_vel(p);
+    if(p->X11_q == 2) omega_(1) = Qext*ramp_vel(p);
+    if(p->X11_r == 2) omega_(2) = Rext*ramp_vel(p);
+
     h_ = I_*omega_;
-    
-    dh_ << 0.0,0.0,0.0;
-    
-    de_ = 0.5*G_.transpose()*I_.inverse()*h_;
+
+    de_ = 0.5*G_.transpose()*omega_;
 }
 
 double sixdof_motionext_fixed::ramp_vel(lexer *p)

--- a/src/6DOF_motionext_wavemaker.cpp
+++ b/src/6DOF_motionext_wavemaker.cpp
@@ -61,40 +61,58 @@ void sixdof_motionext_wavemaker::ini(lexer *p, ghostcell *pgc)
 void sixdof_motionext_wavemaker::motionext_trans(lexer *p, ghostcell *pgc, Eigen::Vector3d& dp_, Eigen::Vector3d& dc_)
 {
     // find correct time step
-    if((p->simtime>data[timecount][0]))
-    timecount_old=timecount;
-    
-	while(p->simtime>data[timecount][0])
-	++timecount;
-    
-    
-        Uext = 0.0;
+    if (p->simtime <= te)
+    {
+        if(p->simtime>data[timecount][0])
+        timecount_old=timecount;
         
-        if(p->simtime>=ts && p->simtime<=te && timecount<ptnum-1 && timecount_old<ptnum)
-        Uext = (data[timecount][1]-data[timecount_old][1])/(data[timecount][0]-data[timecount_old][0]);
-        
-        if(p->mpirank==0)
-        cout<<"6DOF_motion  Uext "<<Uext<<endl;
-        
-        dp_(0) = 0.0;
-        dc_(0) = Uext*ramp_vel(p);
+        while(p->simtime>data[timecount][0])
+        ++timecount;
+    }
+    
+    
+        if (p->X11_u == 2)
+        {
+            Uext = 0.0;
+            
+            if(p->simtime>=ts && p->simtime<=te)
+            Uext = (data[timecount][1]-data[timecount_old][1])/(data[timecount][0]-data[timecount_old][0]);
+            
+            if(p->mpirank==0)
+            cout<<"6DOF_motion  Uext "<<Uext<<endl;
+            
+            dp_(0) = 0.0;
+            dc_(0) = Uext*ramp_vel(p);
+        }
 
-        dp_(1) = 0.0;
-        dc_(1) = 0.0;
+        if (p->X11_v == 2)
+        {
+            dp_(1) = 0.0;
+            dc_(1) = 0.0;
+        }
         
-        dp_(2) = 0.0;
-        dc_(2) = 0.0;
+        if (p->X11_w == 2)
+        {
+            dp_(2) = 0.0;
+            dc_(2) = 0.0;
+        }
 }
 
 void sixdof_motionext_wavemaker::motionext_rot(lexer *p, Eigen::Vector3d& dh_, Eigen::Vector3d& h_, Eigen::Vector4d& de_, Eigen::Matrix<double, 3, 4>&G_,  Eigen::Matrix3d&I_)
 {
-        dh_ << 0.0,0.0,0.0;
+        if (p->X11_p == 2) dh_(0) = 0.0;
+        if (p->X11_q == 2) dh_(1) = 0.0;
+        if (p->X11_r == 2) dh_(2) = 0.0;
         
-        omega_ << 0.0, 0.0, 0.0;
+        omega_ = I_.inverse() * h_;
+        
+        if (p->X11_p == 2) omega_(0) = 0.0;
+        if (p->X11_q == 2) omega_(1) = 0.0;
+        if (p->X11_r == 2) omega_(2) = 0.0;
         
         h_ = I_*omega_;
         
-        de_ = 0.5*G_.transpose()*I_.inverse()*h_;
+        de_ = 0.5*G_.transpose()*omega_;
 }
 
 double sixdof_motionext_wavemaker::ramp_vel(lexer *p)

--- a/src/6DOF_motionext_wavemaker.h
+++ b/src/6DOF_motionext_wavemaker.h
@@ -66,7 +66,7 @@ private:
     int rowcount,colcount;
     int colnum;
     double val;
-    double **data;
+    std::vector<std::vector<double>> data;
     double ts,te;
     int timecount,timecount_old;
     

--- a/src/6DOF_motionext_wavemaker_read.cpp
+++ b/src/6DOF_motionext_wavemaker_read.cpp
@@ -34,43 +34,16 @@ void sixdof_motionext_wavemaker::read_format_1(lexer *p, ghostcell *pgc)
 	
 	sprintf(name,"6DOF_motion.dat");
 
-// open file and count
-	ifstream file(name, ios_base::in);
-	
-	if(!file)
-	cout<<endl<<("no '6DOF_motion.dat' file found")<<endl<<endl;
-
-    
-    count=0;
-	while(!file.eof())
-	{
-        for(qn=0;qn<colnum;++qn)
-        file>>val;
-	++count;
-	}
-	ptnum=count;
-    
-	file.close();
-    
-// allocate
-    p->Darray(data,ptnum,colnum);
-    
-
-// re.open file
-    file.open (name, ios_base::in);
-	
-	if(!file)
-	cout<<endl<<("no '6DOF_motion.dat' file found")<<endl<<endl;
-    
- // read file   
-    rowcount=colcount=0;
-	while(!file.eof())
-	{
-        for(qn=0;qn<colnum;++qn)
-        file>>data[rowcount][qn];
+    try {
+        auto table = readTable(name, colnum);
+        ptnum = table.size();
         
-        ++rowcount;
-	}
+        // copy data directly
+        data = std::move(table);
+    } catch(const std::exception& e) {
+        cout << "Error: " << e.what() << endl;
+        pgc->final(EXIT_FAILURE);
+    }
     
     ts = data[0][0];
     te = data[ptnum-1][0];

--- a/src/6DOF_obj_solve.cpp
+++ b/src/6DOF_obj_solve.cpp
@@ -100,6 +100,7 @@ void sixdof_obj::rk2(lexer *p, ghostcell *pgc, int iter)
         c_ = ck_ + p->dt*dc_;
         h_ = hk_ + p->dt*dh_;
         e_ = ek_ + p->dt*de_;
+        e_.normalize();
     }
     
     if(iter==1)
@@ -108,6 +109,7 @@ void sixdof_obj::rk2(lexer *p, ghostcell *pgc, int iter)
         c_ = 0.5*ck_ + 0.5*c_ + 0.5*p->dt*dc_;
         h_ = 0.5*hk_ + 0.5*h_ + 0.5*p->dt*dh_;
         e_ = 0.5*ek_ + 0.5*e_ + 0.5*p->dt*de_;    
+        e_.normalize();
     }
 }
 
@@ -127,6 +129,7 @@ void sixdof_obj::rk3(lexer *p, ghostcell *pgc, int iter)
         c_ = ck_ + p->dt*dc_;
         h_ = hk_ + p->dt*dh_;
         e_ = ek_ + p->dt*de_;
+        e_.normalize();
     }
     
     if(iter==1)
@@ -135,6 +138,7 @@ void sixdof_obj::rk3(lexer *p, ghostcell *pgc, int iter)
         c_ = 0.75*ck_ + 0.25*c_ + 0.25*p->dt*dc_;
         h_ = 0.75*hk_ + 0.25*h_ + 0.25*p->dt*dh_;
         e_ = 0.75*ek_ + 0.25*e_ + 0.25*p->dt*de_;
+        e_.normalize();
     }  
     
     if(iter==2)
@@ -143,6 +147,7 @@ void sixdof_obj::rk3(lexer *p, ghostcell *pgc, int iter)
         c_ = (1.0/3.0)*ck_ + (2.0/3.0)*c_ + (2.0/3.0)*p->dt*dc_;
         h_ = (1.0/3.0)*hk_ + (2.0/3.0)*h_ + (2.0/3.0)*p->dt*dh_;
         e_ = (1.0/3.0)*ek_ + (2.0/3.0)*e_ + (2.0/3.0)*p->dt*de_;
+        e_.normalize();
     }
 }
 
@@ -155,6 +160,7 @@ void sixdof_obj::rkls3(lexer *p, ghostcell *pgc, int iter)
     c_ = c_ + gamma[iter]*p->dt*dc_ + zeta[iter]*p->dt*dck_;
     h_ = h_ + gamma[iter]*p->dt*dh_ + zeta[iter]*p->dt*dhk_;
     e_ = e_ + gamma[iter]*p->dt*de_ + zeta[iter]*p->dt*dek_;
+    e_.normalize();
     
     dpk_ = dp_;
     dck_ = dc_;
@@ -176,11 +182,13 @@ void sixdof_obj::solve_eqmotion_oneway_onestep(lexer *p, ghostcell *pgc, bool fi
         c_ = c_ + p->dt*dc_;
         h_ = h_ + p->dt*dh_;
         e_ = e_ + p->dt*de_;
+        e_.normalize();
 
         p_ = 0.5*pk_ + 0.5*p_ + 0.5*p->dt*dp_;
         c_ = 0.5*ck_ + 0.5*c_ + 0.5*p->dt*dc_;
         h_ = 0.5*hk_ + 0.5*h_ + 0.5*p->dt*dh_;
         e_ = 0.5*ek_ + 0.5*e_ + 0.5*p->dt*de_;         
+        e_.normalize();
 }
 
 


### PR DESCRIPTION
Key Changes
Heave (Memory Safety): `ray_cast_io` function was reading uninitialized stack memory, causing pressure integration failures. This was fixed by splitting the logic into explicitly initialized directional passes (`io_x`, `io_ycorr`, `io_zcorr`) and syncing MPI boundaries.
Pitch/Roll (Kinematics): External constraints previously zeroed the entire angular momentum vector (`dh_`), dampening all rotation. The logic now extracts the true angular velocity (`omega_ = I_.inverse() * h_`), applies constraints *only* to the specific locked axes, and preserves fluid-induced rotations on the free axes.
Stability: Added a bounds check (`timecount < ptnum - 1`) to the motion file reader to prevent out-of-bounds crashes.
