### PR TITLE
Inline fixes

### DIFF
--- a/src/nhflow_HLLYL.cpp
+++ b/src/nhflow_HLLYL.cpp
@@ -325,7 +325,7 @@ void nhflow_HLLYL::HLL_E(lexer *&p, fdm_nhf *&d)
 }
 
 
-inline double nhflow_HLLYL::limiter(double v1, double v2)
+double nhflow_HLLYL::limiter(double v1, double v2)
 {
     val=0.0;
     

--- a/src/nhflow_HLLYL.h
+++ b/src/nhflow_HLLYL.h
@@ -56,7 +56,7 @@ private:
     void HLL(lexer*&, fdm_nhf*&, double*, double*, double*, double*);
     void HLL_E(lexer*&, fdm_nhf*&);
     
-    double limiter(double, double);
+    inline double limiter(double, double);
     
 	double dx,dy,dz;
 	double udir,vdir,wdir;

--- a/src/nhflow_reconstruct.h
+++ b/src/nhflow_reconstruct.h
@@ -38,13 +38,13 @@ class nhflow_reconstruct
 {
 public:
 
-    virtual inline void reconstruct_2D_x(lexer*,ghostcell*,fdm_nhf*,slice&,slice&,slice&)=0;
-    virtual inline void reconstruct_2D_y(lexer*,ghostcell*,fdm_nhf*,slice&,slice&,slice&)=0;
-    virtual inline void reconstruct_2D_WL(lexer*,ghostcell*,fdm_nhf*)=0;
+    virtual void reconstruct_2D_x(lexer*,ghostcell*,fdm_nhf*,slice&,slice&,slice&)=0;
+    virtual void reconstruct_2D_y(lexer*,ghostcell*,fdm_nhf*,slice&,slice&,slice&)=0;
+    virtual void reconstruct_2D_WL(lexer*,ghostcell*,fdm_nhf*)=0;
     
-    virtual inline void reconstruct_3D_x(lexer*,ghostcell*,fdm_nhf*,double*,double*,double*)=0;
-    virtual inline void reconstruct_3D_y(lexer*,ghostcell*,fdm_nhf*,double*,double*,double*)=0;
-    virtual inline void reconstruct_3D_z(lexer*,ghostcell*,fdm_nhf*,double*,double*,double*)=0;
+    virtual void reconstruct_3D_x(lexer*,ghostcell*,fdm_nhf*,double*,double*,double*)=0;
+    virtual void reconstruct_3D_y(lexer*,ghostcell*,fdm_nhf*,double*,double*,double*)=0;
+    virtual void reconstruct_3D_z(lexer*,ghostcell*,fdm_nhf*,double*,double*,double*)=0;
 
 };
 

--- a/src/nhflow_reconstruct_hires.cpp
+++ b/src/nhflow_reconstruct_hires.cpp
@@ -37,7 +37,7 @@ nhflow_reconstruct_hires::~nhflow_reconstruct_hires()
 {
 }
 
-inline void nhflow_reconstruct_hires::reconstruct_2D_x(lexer* p, ghostcell *pgc, fdm_nhf*, slice& f, slice &fs, slice &fn)
+void nhflow_reconstruct_hires::reconstruct_2D_x(lexer* p, ghostcell *pgc, fdm_nhf*, slice& f, slice &fs, slice &fn)
 {
     SLICELOOP4
     dfdx(i,j) = 0.0;
@@ -65,7 +65,7 @@ inline void nhflow_reconstruct_hires::reconstruct_2D_x(lexer* p, ghostcell *pgc,
     pgc->gcsl_start1(p,fn,1);
 }
 
-inline void nhflow_reconstruct_hires::reconstruct_2D_y(lexer* p, ghostcell *pgc, fdm_nhf*, slice& f, slice &fe, slice &fw)
+void nhflow_reconstruct_hires::reconstruct_2D_y(lexer* p, ghostcell *pgc, fdm_nhf*, slice& f, slice &fe, slice &fw)
 {
     if(p->j_dir==1)
     {
@@ -97,7 +97,7 @@ inline void nhflow_reconstruct_hires::reconstruct_2D_y(lexer* p, ghostcell *pgc,
     }
 }
 
-inline void nhflow_reconstruct_hires::reconstruct_2D_WL(lexer* p, ghostcell *pgc, fdm_nhf *d)
+void nhflow_reconstruct_hires::reconstruct_2D_WL(lexer* p, ghostcell *pgc, fdm_nhf *d)
 {
     // water level  
     SLICELOOP1
@@ -129,7 +129,7 @@ inline void nhflow_reconstruct_hires::reconstruct_2D_WL(lexer* p, ghostcell *pgc
         
 }
 
-inline void nhflow_reconstruct_hires::reconstruct_3D_x(lexer* p, ghostcell *pgc, fdm_nhf *d, double *Fx, double *Fs, double *Fn)
+void nhflow_reconstruct_hires::reconstruct_3D_x(lexer* p, ghostcell *pgc, fdm_nhf *d, double *Fx, double *Fs, double *Fn)
 {
     // gradient
     LOOP
@@ -157,7 +157,7 @@ inline void nhflow_reconstruct_hires::reconstruct_3D_x(lexer* p, ghostcell *pgc,
     pgc->start1V(p,Fn,1);
 }
 
-inline void nhflow_reconstruct_hires::reconstruct_3D_y(lexer* p, ghostcell *pgc, fdm_nhf *d, double *Fy, double *Fe, double *Fw)
+void nhflow_reconstruct_hires::reconstruct_3D_y(lexer* p, ghostcell *pgc, fdm_nhf *d, double *Fy, double *Fe, double *Fw)
 {
     // gradient
     if(p->j_dir==1)
@@ -188,7 +188,7 @@ inline void nhflow_reconstruct_hires::reconstruct_3D_y(lexer* p, ghostcell *pgc,
     }
 }
 
-inline void nhflow_reconstruct_hires::reconstruct_3D_z(lexer* p, ghostcell *pgc, fdm_nhf *d, double *Fz, double *Fb, double *Ft)
+void nhflow_reconstruct_hires::reconstruct_3D_z(lexer* p, ghostcell *pgc, fdm_nhf *d, double *Fz, double *Fb, double *Ft)
 {
     // gradient
     LOOP
@@ -216,7 +216,7 @@ inline void nhflow_reconstruct_hires::reconstruct_3D_z(lexer* p, ghostcell *pgc,
     pgc->start3V(p,Ft,1);
 }
 
-inline double nhflow_reconstruct_hires::limiter(double v1, double v2)
+double nhflow_reconstruct_hires::limiter(double v1, double v2)
 {
     val=0.0;
     

--- a/src/nhflow_reconstruct_hires.h
+++ b/src/nhflow_reconstruct_hires.h
@@ -41,13 +41,13 @@ public:
 	nhflow_reconstruct_hires(lexer*,patchBC_interface*);
 	virtual ~nhflow_reconstruct_hires();
 
-    inline void reconstruct_2D_x(lexer*,ghostcell*,fdm_nhf*,slice&,slice&,slice&) override final;
-    inline void reconstruct_2D_y(lexer*,ghostcell*,fdm_nhf*,slice&,slice&,slice&) override final;
-    inline void reconstruct_2D_WL(lexer*,ghostcell*,fdm_nhf*) override final;
+    void reconstruct_2D_x(lexer*,ghostcell*,fdm_nhf*,slice&,slice&,slice&) override final;
+    void reconstruct_2D_y(lexer*,ghostcell*,fdm_nhf*,slice&,slice&,slice&) override final;
+    void reconstruct_2D_WL(lexer*,ghostcell*,fdm_nhf*) override final;
     
-    inline void reconstruct_3D_x(lexer*,ghostcell*,fdm_nhf*,double*,double*,double*) override final;
-    inline void reconstruct_3D_y(lexer*,ghostcell*,fdm_nhf*,double*,double*,double*) override final;
-    inline void reconstruct_3D_z(lexer*,ghostcell*,fdm_nhf*,double*,double*,double*) override final;
+    void reconstruct_3D_x(lexer*,ghostcell*,fdm_nhf*,double*,double*,double*) override final;
+    void reconstruct_3D_y(lexer*,ghostcell*,fdm_nhf*,double*,double*,double*) override final;
+    void reconstruct_3D_z(lexer*,ghostcell*,fdm_nhf*,double*,double*,double*) override final;
     
     slice4 dfdx,dfdy;
     double *DFDX;

--- a/src/nhflow_reconstruct_weno.cpp
+++ b/src/nhflow_reconstruct_weno.cpp
@@ -38,7 +38,7 @@ nhflow_reconstruct_weno::~nhflow_reconstruct_weno()
 {
 }
 
-inline void nhflow_reconstruct_weno::reconstruct_2D_x(lexer* p, ghostcell *pgc, fdm_nhf*, slice& f, slice &fs, slice &fn)
+void nhflow_reconstruct_weno::reconstruct_2D_x(lexer* p, ghostcell *pgc, fdm_nhf*, slice& f, slice &fs, slice &fn)
 {
     uf=1;
     vf=0;
@@ -106,7 +106,7 @@ inline void nhflow_reconstruct_weno::reconstruct_2D_x(lexer* p, ghostcell *pgc, 
     }*/
 }
 
-inline void nhflow_reconstruct_weno::reconstruct_2D_y(lexer* p, ghostcell *pgc, fdm_nhf*, slice& f, slice &fe, slice &fw)
+void nhflow_reconstruct_weno::reconstruct_2D_y(lexer* p, ghostcell *pgc, fdm_nhf*, slice& f, slice &fe, slice &fw)
 {
     uf=0;
     vf=1;
@@ -140,7 +140,7 @@ inline void nhflow_reconstruct_weno::reconstruct_2D_y(lexer* p, ghostcell *pgc, 
     pgc->gcsl_start2(p,fw,1);
 }
 
-inline void nhflow_reconstruct_weno::reconstruct_2D_WL(lexer* p, ghostcell *pgc, fdm_nhf *d)
+void nhflow_reconstruct_weno::reconstruct_2D_WL(lexer* p, ghostcell *pgc, fdm_nhf *d)
 {
     // water level  
     SLICELOOP1
@@ -171,7 +171,7 @@ inline void nhflow_reconstruct_weno::reconstruct_2D_WL(lexer* p, ghostcell *pgc,
     pgc->gcsl_start2(p,d->Dw,1);
 }
 
-inline void nhflow_reconstruct_weno::reconstruct_3D_x(lexer* p, ghostcell *pgc, fdm_nhf *d, double *Fx, double *Fs, double *Fn)
+void nhflow_reconstruct_weno::reconstruct_3D_x(lexer* p, ghostcell *pgc, fdm_nhf *d, double *Fx, double *Fs, double *Fn)
 {
     uf=1;
     vf=0;
@@ -242,7 +242,7 @@ inline void nhflow_reconstruct_weno::reconstruct_3D_x(lexer* p, ghostcell *pgc, 
     }*/
 }
 
-inline void nhflow_reconstruct_weno::reconstruct_3D_y(lexer* p, ghostcell *pgc, fdm_nhf *d, double *Fy, double *Fe, double *Fw)
+void nhflow_reconstruct_weno::reconstruct_3D_y(lexer* p, ghostcell *pgc, fdm_nhf *d, double *Fy, double *Fe, double *Fw)
 {
     uf=0;
     vf=1;
@@ -276,7 +276,7 @@ inline void nhflow_reconstruct_weno::reconstruct_3D_y(lexer* p, ghostcell *pgc, 
     pgc->start2V(p,Fw,1);
 }
 
-inline void nhflow_reconstruct_weno::reconstruct_3D_z(lexer* p, ghostcell *pgc, fdm_nhf *d, double *Fz, double *Fb, double *Ft)
+void nhflow_reconstruct_weno::reconstruct_3D_z(lexer* p, ghostcell *pgc, fdm_nhf *d, double *Fz, double *Fb, double *Ft)
 {
     if(p->A514==4)
     {
@@ -335,7 +335,7 @@ inline void nhflow_reconstruct_weno::reconstruct_3D_z(lexer* p, ghostcell *pgc, 
     pgc->start3V(p,Ft,1);
 }
 
-inline void nhflow_reconstruct_weno::iqmin(lexer *p, double *F)
+void nhflow_reconstruct_weno::iqmin(lexer *p, double *F)
 {	 
     q1 = F[Im2JK];
     q2 = F[Im1JK];
@@ -344,7 +344,7 @@ inline void nhflow_reconstruct_weno::iqmin(lexer *p, double *F)
     q5 = F[Ip2JK];
 }
 
-inline void nhflow_reconstruct_weno::jqmin(lexer *p, double *F)
+void nhflow_reconstruct_weno::jqmin(lexer *p, double *F)
 {
     q1 = F[IJm2K];
     q2 = F[IJm1K];
@@ -353,7 +353,7 @@ inline void nhflow_reconstruct_weno::jqmin(lexer *p, double *F)
     q5 = F[IJp2K];
 }
 
-inline void nhflow_reconstruct_weno::kqmin(lexer *p, double *F)
+void nhflow_reconstruct_weno::kqmin(lexer *p, double *F)
 {
     q1 = F[IJKm2];
     q2 = F[IJKm1];
@@ -362,7 +362,7 @@ inline void nhflow_reconstruct_weno::kqmin(lexer *p, double *F)
     q5 = F[IJKp2];
 }
 
-inline void nhflow_reconstruct_weno::iqmax(lexer *p, double *F)
+void nhflow_reconstruct_weno::iqmax(lexer *p, double *F)
 {
     q1 = F[Im1JK];
     q2 = F[IJK];
@@ -371,7 +371,7 @@ inline void nhflow_reconstruct_weno::iqmax(lexer *p, double *F)
     q5 = F[Ip3JK];
 }
 
-inline void nhflow_reconstruct_weno::jqmax(lexer *p, double *F)
+void nhflow_reconstruct_weno::jqmax(lexer *p, double *F)
 {
     q1 = F[IJm1K];
     q2 = F[IJK];
@@ -380,7 +380,7 @@ inline void nhflow_reconstruct_weno::jqmax(lexer *p, double *F)
     q5 = F[IJp3K];
 }
 
-inline void nhflow_reconstruct_weno::kqmax(lexer *p, double *F)
+void nhflow_reconstruct_weno::kqmax(lexer *p, double *F)
 {
 	q1 = F[IJKm1];
     q2 = F[IJK];
@@ -389,7 +389,7 @@ inline void nhflow_reconstruct_weno::kqmax(lexer *p, double *F)
     q5 = F[IJKp3];
 }
 
-inline void nhflow_reconstruct_weno::iqmin_sl(lexer *p, slice& f)
+void nhflow_reconstruct_weno::iqmin_sl(lexer *p, slice& f)
 {	
 	q1 = f(i-2,j);
 	q2 = f(i-1,j);
@@ -398,7 +398,7 @@ inline void nhflow_reconstruct_weno::iqmin_sl(lexer *p, slice& f)
 	q5 = f(i+2,j);
 }
 
-inline void nhflow_reconstruct_weno::jqmin_sl(lexer *p, slice& f)
+void nhflow_reconstruct_weno::jqmin_sl(lexer *p, slice& f)
 {
 	q1 = f(i,j-2);
 	q2 = f(i,j-1);
@@ -407,7 +407,7 @@ inline void nhflow_reconstruct_weno::jqmin_sl(lexer *p, slice& f)
 	q5 = f(i,j+2);
 }
 
-inline void nhflow_reconstruct_weno::iqmax_sl(lexer *p, slice& f)
+void nhflow_reconstruct_weno::iqmax_sl(lexer *p, slice& f)
 {
 	q1 = f(i-1,j);
 	q2 = f(i,j);
@@ -416,7 +416,7 @@ inline void nhflow_reconstruct_weno::iqmax_sl(lexer *p, slice& f)
 	q5 = f(i+3,j);
 }
 
-inline void nhflow_reconstruct_weno::jqmax_sl(lexer *p, slice& f)
+void nhflow_reconstruct_weno::jqmax_sl(lexer *p, slice& f)
 {
 	q1 = f(i,j-1);
 	q2 = f(i,j);
@@ -425,7 +425,7 @@ inline void nhflow_reconstruct_weno::jqmax_sl(lexer *p, slice& f)
 	q5 = f(i,j+3);
 }
 
-inline double nhflow_reconstruct_weno::limiter(double v1, double v2)
+double nhflow_reconstruct_weno::limiter(double v1, double v2)
 {
     val=0.0;
     

--- a/src/nhflow_reconstruct_weno.h
+++ b/src/nhflow_reconstruct_weno.h
@@ -41,13 +41,13 @@ public:
 	nhflow_reconstruct_weno(lexer*,patchBC_interface*);
 	virtual ~nhflow_reconstruct_weno();
 
-    inline void reconstruct_2D_x(lexer*,ghostcell*,fdm_nhf*,slice&,slice&,slice&) override final;
-    inline void reconstruct_2D_y(lexer*,ghostcell*,fdm_nhf*,slice&,slice&,slice&) override final;
-    inline void reconstruct_2D_WL(lexer*,ghostcell*,fdm_nhf*) override final;
+    void reconstruct_2D_x(lexer*,ghostcell*,fdm_nhf*,slice&,slice&,slice&) override final;
+    void reconstruct_2D_y(lexer*,ghostcell*,fdm_nhf*,slice&,slice&,slice&) override final;
+    void reconstruct_2D_WL(lexer*,ghostcell*,fdm_nhf*) override final;
     
-    inline void reconstruct_3D_x(lexer*,ghostcell*,fdm_nhf*,double*,double*,double*) override final;
-    inline void reconstruct_3D_y(lexer*,ghostcell*,fdm_nhf*,double*,double*,double*) override final;
-    inline void reconstruct_3D_z(lexer*,ghostcell*,fdm_nhf*,double*,double*,double*) override final;
+    void reconstruct_3D_x(lexer*,ghostcell*,fdm_nhf*,double*,double*,double*) override final;
+    void reconstruct_3D_y(lexer*,ghostcell*,fdm_nhf*,double*,double*,double*) override final;
+    void reconstruct_3D_z(lexer*,ghostcell*,fdm_nhf*,double*,double*,double*) override final;
     
     slice4 dfdx,dfdy;
 

--- a/src/sflow_reconstruct_weno.cpp
+++ b/src/sflow_reconstruct_weno.cpp
@@ -137,7 +137,7 @@ void sflow_reconstruct_weno::reconstruct_WL(lexer* p, ghostcell *pgc, fdm2D *b)
     pgc->gcsl_start2(p,b->Dw,1);
 }
 
-inline void sflow_reconstruct_weno::iqmin(lexer *p, slice& f)
+void sflow_reconstruct_weno::iqmin(lexer *p, slice& f)
 {	
 	q1 = f(i-2,j);
 	q2 = f(i-1,j);
@@ -146,7 +146,7 @@ inline void sflow_reconstruct_weno::iqmin(lexer *p, slice& f)
 	q5 = f(i+2,j);
 }
 
-inline void sflow_reconstruct_weno::jqmin(lexer *p, slice& f)
+void sflow_reconstruct_weno::jqmin(lexer *p, slice& f)
 {
 	q1 = f(i,j-2);
 	q2 = f(i,j-1);
@@ -155,7 +155,7 @@ inline void sflow_reconstruct_weno::jqmin(lexer *p, slice& f)
 	q5 = f(i,j+2);
 }
 
-inline void sflow_reconstruct_weno::iqmax(lexer *p, slice& f)
+void sflow_reconstruct_weno::iqmax(lexer *p, slice& f)
 {
 	q1 = f(i-1,j);
 	q2 = f(i,j);
@@ -164,7 +164,7 @@ inline void sflow_reconstruct_weno::iqmax(lexer *p, slice& f)
 	q5 = f(i+3,j);
 }
 
-inline void sflow_reconstruct_weno::jqmax(lexer *p, slice& f)
+void sflow_reconstruct_weno::jqmax(lexer *p, slice& f)
 {
 	q1 = f(i,j-1);
 	q2 = f(i,j);

--- a/src/sflow_reconstruct_weno.h
+++ b/src/sflow_reconstruct_weno.h
@@ -48,12 +48,10 @@ public:
     slice4 dfdx,dfdy;
 
 private:
-    void iqmin(lexer*, slice&);
-    void iqmax(lexer*, slice&);
-    void jqmin(lexer*, slice&);
-    void jqmax(lexer*, slice&);
-    
-    double limiter(double, double);
+    inline void iqmin(lexer*, slice&);
+    inline void iqmax(lexer*, slice&);
+    inline void jqmin(lexer*, slice&);
+    inline void jqmax(lexer*, slice&);
 
     double ivel1,ivel2,jvel1,jvel2;
     int qq;

--- a/src/slice1.cpp
+++ b/src/slice1.cpp
@@ -51,7 +51,7 @@ void slice1::fieldgcalloc(lexer* p)
     p->Darray(gcfeld,gcfeldsize,4,4);
 }
 
-inline double & slice1::operator()(int ii, int jj)
+double & slice1::operator()(int ii, int jj)
 {
     if(pp->mgcsl1[(ii-imin)*jmax + (jj-jmin)]<2)
     return V[(ii-imin)*jmax + (jj-jmin)];

--- a/src/slice1.h
+++ b/src/slice1.h
@@ -32,7 +32,7 @@ public:
 	slice1(lexer*);
 	virtual ~slice1();
 
-    inline double& operator()(int, int) override final;
+    double& operator()(int, int) override final;
     void ggcpol(lexer*) override final;
 
 private:

--- a/src/slice2.cpp
+++ b/src/slice2.cpp
@@ -53,7 +53,7 @@ void slice2::fieldgcalloc(lexer* p)
     p->Darray(gcfeld,gcfeldsize,4,4);
 }
 
-inline double & slice2::operator()(int ii, int jj)
+double & slice2::operator()(int ii, int jj)
 {
     if(pp->mgcsl2[(ii-imin)*jmax + (jj-jmin)]<2)
     return V[(ii-imin)*jmax + (jj-jmin)];

--- a/src/slice2.h
+++ b/src/slice2.h
@@ -32,7 +32,7 @@ public:
     slice2(lexer*);
     virtual ~slice2();
 
-    inline double& operator()(int, int) override final;
+    double& operator()(int, int) override final;
     void ggcpol(lexer*) override final;
 
 private:

--- a/src/slice4.cpp
+++ b/src/slice4.cpp
@@ -51,7 +51,7 @@ void slice4::fieldgcalloc(lexer* p)
     p->Darray(gcfeld,gcfeldsize,4,4);
 }
 
-inline double & slice4::operator()(int ii, int jj)
+double & slice4::operator()(int ii, int jj)
 {
     if(pp->mgcsl4[(ii-imin)*jmax + (jj-jmin)]<2)
     return V[(ii-imin)*jmax + (jj-jmin)];

--- a/src/slice4.h
+++ b/src/slice4.h
@@ -34,7 +34,7 @@ public:
     slice4(lexer*);
     virtual ~slice4();
 
-    inline double& operator()(int, int) override final;
+    double& operator()(int, int) override final;
     void ggcpol(lexer*) override final;
 
 private:


### PR DESCRIPTION
Update inline keywords where necessary

- slice::operator
inline would result in failing linking

- sflow_reconstruct_weno & nhflow_WLLYL
inline should be added to header only

- nhflow_reconstruct*
inline would result in failing linking